### PR TITLE
Added policy to check for valid rolebinding when using k8s rbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Current policies in this repo:
 - [ocp-43-deprecated-apiversions.rego](policy/ocp-43-deprecated-apiversions.rego)
     - deny rules for OCP 4.3 apiVersion deprecations. Changing OCP specific kinds from v1 to *.openshift.io/v1
 
+- [k8s-validation-rolebinding.rego](policy/k8s-validation-rolebinding.rego)
+    - deny rules to check roleRef.apiGroup and roleRef.kind for rbac.authorization.k8s.io/v1:RoleBinding are set, which were not required in OCP 3.x
+
 ## 3rd Party Policies
 A list of git repos that contain rego polices which can be combined with this repo:
 - [deprek8ion: Rego policies to monitor Kubernetes APIs deprecations](https://github.com/swade1987/deprek8ion)

--- a/policy/k8s-validation-rolebinding.rego
+++ b/policy/k8s-validation-rolebinding.rego
@@ -1,0 +1,50 @@
+package main
+
+# catch all
+deny[msg] {
+  msg := _deny
+}
+
+deny[msg] {
+  input.apiVersion == "template.openshift.io/v1"
+  input.kind == "Template"
+  obj := input.objects[_]
+  msg := _deny with input as obj
+}
+
+deny[msg] {
+  input.apiVersion != "template.openshift.io/v1"
+  input.kind != "Template"
+  obj := input.objects[_]
+  msg := _deny
+}
+
+deny[msg] {
+  input.apiVersion == "v1"
+  input.kind == "List"
+  obj := input.items[_]
+  msg := _deny with input as obj
+}
+
+deny[msg] {
+  input.apiVersion != "v1"
+  input.kind != "List"
+  msg := _deny
+}
+
+_deny = msg {
+  input.apiVersion == "rbac.authorization.k8s.io/v1"
+  input.kind == "RoleBinding"
+  input.roleRef
+  not input.roleRef.apiGroup
+  msg := sprintf("%s/%s: RoleBinding roleRef.apiGroup key is null, use rbac.authorization.k8s.io instead.", [input.kind, input.metadata.name])
+}
+
+_deny = msg {
+  input.apiVersion == "rbac.authorization.k8s.io/v1"
+  input.kind == "RoleBinding"
+  input.roleRef
+  input.roleRef.apiGroup
+  not input.roleRef.kind
+  msg := sprintf("%s/%s: RoleBinding roleRef.kind key is null, use ClusterRole or Role instead.", [input.kind, input.metadata.name])
+}


### PR DESCRIPTION
#### What is this PR About?
On 3.x, you didn't need to specify ApiGroup/Kind on RoleBindings. It's required now for 4.x

cc: @redhat-cop/day-in-the-life
