### PR TITLE
Updated conftest download in action to be opa github due to migration

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install conftest
         run: |
           export CONFTEST_VERSION=0.18.2
-          wget https://github.com/instrumenta/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz
+          wget https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz
           tar -C /tmp -xzf conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz
           sudo ln -s /tmp/conftest /usr/local/bin/conftest
           conftest --version

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ A list of git repos that contain rego polices which can be combined with this re
 
 ## Conftest
 conftest is a CLI to execute rego policies. It can be used to test locally before pushing to [OPA](https://www.openpolicyagent.org/).
-- https://www.conftest.dev/install/
+- [https://www.conftest.dev/install/]
 
 ## OPA Playground
 OPA provides a web based playground, which can highlight which lines have been activated. Having issues with your policy? check it out with "Coverage" enabled:
-- https://play.openpolicyagent.org/
+- [https://play.openpolicyagent.org/]


### PR DESCRIPTION
#### What is this PR About?
As conftest now lives under opa repo, have updated download url

#### How do we test this?
Check action triggers correctly

cc: @redhat-cop/day-in-the-life
