### PR TITLE
Added check for memory resources which are template params

### DIFF
--- a/_test/warn-k8s_ocp-deployment_deploymentconfig-bestpractices/list-Deployment.yml
+++ b/_test/warn-k8s_ocp-deployment_deploymentconfig-bestpractices/list-Deployment.yml
@@ -1308,3 +1308,58 @@ items:
                 cpu: 100m
               limits:
                 memory: 3Gi
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app.kubernetes.io/name: Foo
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: ResourcesAsParamsShouldNotFire
+  spec:
+    replicas: 3
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: Foo
+          app.kubernetes.io/instance: Bar
+          app.kubernetes.io/component: FooBar
+          app.kubernetes.io/part-of: Foo
+          app.kubernetes.io/managed-by: Bar
+      spec:
+        containers:
+          - name: Bar
+            env:
+              - name: CONTAINER_MAX_MEMORY
+                valueFrom:
+                  resourceFieldRef:
+                    resource: limits.memory
+            livenessProbe:
+              exec:
+                command:
+                  - /bin/bash
+                  - '-c'
+                  - /opt/eap/bin/livenessProbe.sh
+              failureThreshold: 3
+              initialDelaySeconds: 60
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 1
+            readinessProbe:
+              exec:
+                command:
+                  - /bin/bash
+                  - '-c'
+                  - /opt/eap/bin/readinessProbe.sh
+              failureThreshold: 3
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                memory: ${PARAM}
+                cpu: 1
+              limits:
+                memory: ${PARAM}

--- a/_test/warn-k8s_ocp-deployment_deploymentconfig-bestpractices/list-DeploymentConfig.yml
+++ b/_test/warn-k8s_ocp-deployment_deploymentconfig-bestpractices/list-DeploymentConfig.yml
@@ -1364,3 +1364,60 @@ items:
                 memory: 3Gi
     triggers:
       - type: ConfigChange
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app.kubernetes.io/name: Foo
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: ResourcesAsParamsShouldNotFire
+  spec:
+    replicas: 3
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: Foo
+          app.kubernetes.io/instance: Bar
+          app.kubernetes.io/component: FooBar
+          app.kubernetes.io/part-of: Foo
+          app.kubernetes.io/managed-by: Bar
+      spec:
+        containers:
+          - name: Bar
+            env:
+              - name: CONTAINER_MAX_MEMORY
+                valueFrom:
+                  resourceFieldRef:
+                    resource: limits.memory
+            livenessProbe:
+              exec:
+                command:
+                  - /bin/bash
+                  - '-c'
+                  - /opt/eap/bin/livenessProbe.sh
+              failureThreshold: 3
+              initialDelaySeconds: 60
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 1
+            readinessProbe:
+              exec:
+                command:
+                  - /bin/bash
+                  - '-c'
+                  - /opt/eap/bin/readinessProbe.sh
+              failureThreshold: 3
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                memory: ${PARAM}
+                cpu: 1
+              limits:
+                memory: ${PARAM}
+    triggers:
+      - type: ConfigChange

--- a/policy/warn-k8s_ocp-deployment_deploymentconfig-bestpractices.rego
+++ b/policy/warn-k8s_ocp-deployment_deploymentconfig-bestpractices.rego
@@ -89,6 +89,8 @@ warn[msg] {
 
   container := input.spec.template.spec.containers[_]
 
+  not startswith(container.resources.requests.memory, "$")
+  not startswith(container.resources.limits.memory, "$")
   not isResourceMemoryUnitsValid with input as container
 
   msg := sprintf("%s/%s: container '%s' memory resources for limits or requests (%s / %s) has an incorrect unit. See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes", [input.kind, input.metadata.name, container.name, container.resources.limits.memory, container.resources.requests.memory])
@@ -136,6 +138,9 @@ warn[msg] {
   openshift.isDeploymentOrDeploymentConfig
 
   container := input.spec.template.spec.containers[_]
+
+  not startswith(container.resources.requests.memory, "$")
+  not startswith(container.resources.limits.memory, "$")
 
   isResourceMemoryInverted with input as container
 
@@ -327,6 +332,8 @@ warn[msg] {
   upperBound := 6 * gb
 
   container := input.spec.template.spec.containers[_]
+
+  not startswith(container.resources.limits.memory, "$")
   memoryInBytes := units.parse_bytes(container.resources.limits.memory)
   memoryInBytes > upperBound
 
@@ -344,6 +351,8 @@ warn[msg] {
   upperBound := 2 * gb
 
   container := input.spec.template.spec.containers[_]
+
+  not startswith(container.resources.requests.memory, "$")
   memoryInBytes := units.parse_bytes(container.resources.requests.memory)
   memoryInBytes > upperBound
 


### PR DESCRIPTION
#### What is this PR About?
Noticed a random CI failure containers-quickstarts. After a bit of digging, spotted:

 ```
✗ _test/warn-k8s_ocp-deployment_deploymentconfig-bestpractices/list-Deployment.yml
   (in test file _test/conftest.sh, line 107)
     `[ "$status" -eq 0 ]' failed
   Error: get test result: running warn rules: run multiple queries: run query: evaluating policy: policy/warn-k8s_ocp-deployment_deploymentconfig-bestpractices.rego:146: eval_builtin_error: units.parse_bytes: units.parse_bytes error: no byte amount provided
   Usage:
     conftest test <file> [file...] [flags]

   Flags:
         --all-namespaces      find deny and warn rules in all namespaces. If set, the flag "namespace" is ignored
         --combine             combine all given config files to be evaluated together
     -d, --data strings        A list of paths from which data for the rego policies will be recursively loaded
         --fail-on-warn        return a non-zero exit code if only warnings are found
     -h, --help                help for test
         --ignore string       a regex pattern which can be used for ignoring some files/directories in a given input. i.e.: ignoring yamls: --ignore=".*.yaml"
     -i, --input string        input type for given source, especially useful when using conftest with stdin, valid options are: [toml tf hcl hcl1 cue ini yml yaml json Dockerfile edn vcl xml]
         --namespace strings   namespace in which to find deny and warn rules (default [main])
     -o, --output string       output format for conftest results - valid options are: [stdout json tap table]
         --trace               enable more verbose trace output for rego queries
     -u, --update strings      a list of urls can be provided to the update flag, which will download before the tests run

   Global Flags:
         --no-color        disable color when printing
     -p, --policy string   path to the Rego policy files directory. For the test command, specifying a specific .rego file is allowed. (default "policy")
```

which is because the memory value is `${MEMORY_REQUEST}` which isn't a valid value to pass to units.parse_bytes.

NOTE: CPU policies also need fixing.

#### How do we test this?
Check action output doesn't fail with the above error.

cc: @redhat-cop/rego-policies
