### PR TITLE
Updated gatekeeper deploy to only validate non control based namespaces

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -9,18 +9,28 @@ Every policy must have a test_data directory; within that directory, there shoul
 - integration: should contain valid YAML which can be deployed to a cluster which only triggers the policy under-test
 
 Each policy must have a BATS test executed by its usecase:
-- unit test files will be executed by [_test/conftest-unittests.sh].
-- integration test files will be executed by [_test/gatekeeper-integrationtests.sh]. 
+- unit test files will be executed by [_test/conftest-unittests.sh](_test/conftest-unittests.sh).
+- integration test files will be executed by [_test/gatekeeper-integrationtests.sh](_test/gatekeeper-integrationtests.sh). 
 
 ## Execute unit tests
 ```bash
-rm -rf /tmp/rhcop; bats _test/conftest-unittests.sh
+bats _test/conftest-unittests.sh
 ```
 
 ## Execute integration units
 ```bash
-_test/deploy-gatekeeper.sh
-rm -rf /tmp/rhrepo; bats _test/gatekeeper-integrationtests.sh
+_test/deploy-gatekeeper.sh deploy_gatekeeper
+_test/deploy-gatekeeper.sh deploy_constraints
+bats _test/gatekeeper-integrationtests.sh
+```
+
+### Limit Gatekeeper to integration test project only
+By default, Gatekeeper watches all projects, unless they are labeled `control-plane` or `admission.gatekeeper.sh/ignore`.
+If you only want Gatekeeper to watch the project created by [_test/gatekeeper-integrationtests.sh](_test/gatekeeper-integrationtests.sh),
+run the below before `deploy_constraints`:
+
+```bash
+_test/deploy-gatekeeper.sh patch_namespaceselector
 ```
 
 ## Tools used for testing

--- a/_test/conftest-unittests.sh
+++ b/_test/conftest-unittests.sh
@@ -4,6 +4,10 @@ load bats-support-clone
 load test_helper/bats-support/load
 load test_helper/redhatcop-bats-library/load
 
+setup_file() {
+  rm -rf /tmp/rhcop
+}
+
 ####################
 # all-namespaces
 ####################

--- a/_test/deploy-gatekeeper.sh
+++ b/_test/deploy-gatekeeper.sh
@@ -1,11 +1,42 @@
 #!/usr/bin/env bash
 
+command -v oc &> /dev/null || { echo >&2 'ERROR: oc not installed - Aborting'; exit 1; }
+command -v konstraint &> /dev/null || { echo >&2 'ERROR: konstraint not installed - Aborting'; exit 1; }
+
+gatekeeper_version="v3.1.0-beta.10"
+
+cleanup_gatekeeper_constraints() {
+  echo ""
+  echo "Deleting all ConstraintTemplates..."
+  oc delete constrainttemplate.templates.gatekeeper.sh --all --ignore-not-found=true
+
+  find policy/* -name "template.yaml" -type f -exec rm -f {} \;
+  find policy/* -name "constraint.yaml" -type f -exec rm -f {} \;
+}
+
+cleanup_gatekeeper() {
+  echo ""
+  echo "Cleaning up previous gatekeeper installation..."
+  oc delete config.config.gatekeeper.sh -n gatekeeper-system --all --ignore-not-found=true
+  oc delete -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/${gatekeeper_version}/deploy/gatekeeper.yaml --ignore-not-found=true
+  oc delete -f gatekeeper/gatekeeper-template-manager.yml --ignore-not-found=true
+}
+
 deploy_gatekeeper() {
   echo ""
+  echo "Patching control-plane related namespaces so that OPA ignores them..."
+  for namespace in $(oc get namespaces -o jsonpath='{.items[*].metadata.name}' | xargs); do
+    if [[ "${namespace}" =~ openshift.* ]] || [[ "${namespace}" =~ kube.* ]] || [[ "${namespace}" =~ default ]]; then
+      oc patch namespace/${namespace} -p='{"metadata":{"labels":{"control-plane":"true"}}}'
+    else
+      # Probably a users project, so leave it alone
+      echo "Skipping: ${namespace}"
+    fi
+  done
+
+  echo ""
   echo "Deploying gatekeeper..."
-  oc delete constrainttemplate.templates.gatekeeper.sh --all --ignore-not-found=true
-  oc delete -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.1.0-beta.10/deploy/gatekeeper.yaml --ignore-not-found=true
-  oc create -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.1.0-beta.10/deploy/gatekeeper.yaml
+  oc create -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/${gatekeeper_version}/deploy/gatekeeper.yaml
 
   echo ""
   echo "Patching gatekeeper to work on OCP..."
@@ -14,6 +45,21 @@ deploy_gatekeeper() {
 
   echo ""
   echo "Waiting for gatekeeper to be ready..."
+  oc rollout status Deployment/gatekeeper-audit -n gatekeeper-system --watch=true
+  oc rollout status Deployment/gatekeeper-controller-manager -n gatekeeper-system --watch=true
+
+  oc create -f gatekeeper/config.yml -n gatekeeper-system
+  oc create -f gatekeeper/gatekeeper-template-manager.yml
+}
+
+patch_namespaceselector_for_webhook() {
+  echo ""
+  echo "Patching ValidatingWebhookConfiguration/gatekeeper-validating-webhook-configuration to only watch namespaces with: 'redhat-cop.github.com/gatekeeper-active == true'..."
+  oc patch ValidatingWebhookConfiguration/gatekeeper-validating-webhook-configuration -p='{"webhooks":[{"name":"validation.gatekeeper.sh","namespaceSelector":{"matchExpressions":[{"key":"redhat-cop.github.com/gatekeeper-active","operator":"In","values":["true"]}]}}]}'
+
+  echo ""
+  echo "Restarting Gatekeeper and waiting for it to be ready..."
+  oc delete pods --all -n gatekeeper-system
   oc rollout status Deployment/gatekeeper-audit -n gatekeeper-system --watch=true
   oc rollout status Deployment/gatekeeper-controller-manager -n gatekeeper-system --watch=true
 }
@@ -37,27 +83,20 @@ generate_constraints() {
 
 deploy_constraints() {
   echo ""
-  echo "Deploying ConstraintTemplates..."
+  echo "Deploying Constraints..."
 
-  for file in $(find policy/* -name "template.yaml" -type f | xargs); do
-    oc create -f "${file}" -o jsonpath="{.metadata.name}" || exit $?
+  # shellcheck disable=SC2038
+  for file in $(find policy/* \( -name "template.yaml" -o -name "constraint.yaml" \) -type f | xargs); do
+    name=$(oc create -f "${file}" -n gatekeeper-system -o name || exit $?)
+    echo "${name}"
 
-    local name="$(yq -r '.metadata.name' "${file}")"
-    echo ""
-
-    until oc get constrainttemplate/${name} -o json | jq ".status.created" | grep -q "true";
-    do
-      echo "Waiting for: .status.created == true"
-      sleep 5s
-    done
-
-    until oc get constrainttemplate/${name} -o json | jq ".status.byPod | length" | grep -q "2";
+    until oc get ${name} -o json | jq ".status.byPod | length" | grep -q "2";
     do
       echo "Waiting for: .status.byPod | length == 2"
       sleep 5s
     done
 
-    until [[ -z $(oc get constrainttemplate/${name} -o json | jq "select(.status.byPod[].errors != null)") ]];
+    until [[ -z $(oc get ${name} -o json | jq "select(.status.byPod[].errors != null)") ]];
     do
       echo "Waiting for: .status.byPod[].errors == ''"
       sleep 5s
@@ -65,17 +104,24 @@ deploy_constraints() {
 
     echo ""
   done
-
-  echo "Deploying Constraints..."
-
-  for file in $(find policy/* -name "constraint.yaml" -type f | xargs); do
-    oc create -n gatekeeper-system -f "${file}" || exit $?
-  done
 }
 
-command -v oc &> /dev/null || { echo >&2 'ERROR: oc not installed - Aborting'; exit 1; }
-command -v konstraint &> /dev/null || { echo >&2 'ERROR: konstraint not installed - Aborting'; exit 1; }
-
-deploy_gatekeeper
-generate_constraints
-deploy_constraints
+# Process arguments
+case $1 in
+  deploy_gatekeeper)
+    cleanup_gatekeeper_constraints
+    cleanup_gatekeeper
+    deploy_gatekeeper
+    ;;
+  patch_namespaceselector)
+    patch_namespaceselector_for_webhook
+    ;;
+  deploy_constraints)
+    cleanup_gatekeeper_constraints
+    generate_constraints
+    deploy_constraints
+    ;;
+  *)
+    echo "Not an option"
+    exit 1
+esac

--- a/_test/gatekeeper-integrationtests.sh
+++ b/_test/gatekeeper-integrationtests.sh
@@ -4,6 +4,23 @@ load bats-support-clone
 load test_helper/bats-support/load
 load test_helper/redhatcop-bats-library/load
 
+setup_file() {
+  export project_name="regopolicies-undertest-$(date +'%d%m%Y-%H%M%S')"
+
+  rm -rf /tmp/rhcop
+  oc process -f _test/namespace-under-test.yml -p=PROJECT_NAME=${project_name} | oc create -f -
+}
+
+teardown_file() {
+  oc delete project/${project_name}
+}
+
+teardown() {
+  if [[ -n "${tmp}" ]]; then
+    oc delete -f "${tmp}" --ignore-not-found=true --wait=true > /dev/null 2>&1
+  fi
+}
+
 ####################
 # all-namespaces
 ####################
@@ -11,21 +28,12 @@ load test_helper/redhatcop-bats-library/load
 @test "_test/all-namespaces/ocp/bestpractices" {
   tmp=$(split_files "_test/all-namespaces/ocp/bestpractices")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 0 ]
-
-  #Cleanup afterwards
-  oc delete -f "${tmp}" --ignore-not-found=true --wait=true
 }
-
-####################
-# combine
-####################
-
-## TODO ##
 
 ####################
 # ocp/bestpractices
@@ -34,7 +42,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/common-k8s-labels-notset" {
   tmp=$(split_files "policy/ocp/bestpractices/common-k8s-labels-notset/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -47,7 +55,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-env-maxmemory-notset" {
   tmp=$(split_files "policy/ocp/bestpractices/container-env-maxmemory-notset/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
   
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -60,7 +68,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-image-latest" {
   tmp=$(split_files "policy/ocp/bestpractices/container-image-latest/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -73,7 +81,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-java-xmx-set" {
   tmp=$(split_files "policy/ocp/bestpractices/container-java-xmx-set/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -90,7 +98,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-labelkey-inconsistent" {
   tmp=$(split_files "policy/ocp/bestpractices/container-labelkey-inconsistent/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -103,7 +111,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-liveness-readinessprobe-equal" {
   tmp=$(split_files "policy/ocp/bestpractices/container-liveness-readinessprobe-equal/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -116,7 +124,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-livenessprobe-notset" {
   tmp=$(split_files "policy/ocp/bestpractices/container-livenessprobe-notset/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -129,7 +137,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-readinessprobe-notset" {
   tmp=$(split_files "policy/ocp/bestpractices/container-readinessprobe-notset/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -142,7 +150,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-resources-limits-cpu-set" {
   tmp=$(split_files "policy/ocp/bestpractices/container-resources-limits-cpu-set/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -156,7 +164,7 @@ load test_helper/redhatcop-bats-library/load
   skip
   tmp=$(split_files "policy/ocp/bestpractices/container-resources-limits-memory-greater-than/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -169,7 +177,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-resources-limits-memory-notset" {
   tmp=$(split_files "policy/ocp/bestpractices/container-resources-limits-memory-notset/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -182,7 +190,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-resources-memoryunit-incorrect" {
   tmp=$(split_files "policy/ocp/bestpractices/container-resources-memoryunit-incorrect/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -197,7 +205,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-resources-requests-cpuunit-incorrect" {
   tmp=$(split_files "policy/ocp/bestpractices/container-resources-requests-cpuunit-incorrect/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -211,7 +219,7 @@ load test_helper/redhatcop-bats-library/load
   skip
   tmp=$(split_files "policy/ocp/bestpractices/container-resources-requests-memory-greater-than/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -224,7 +232,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-secret-mounted-envs" {
   tmp=$(split_files "policy/ocp/bestpractices/container-secret-mounted-envs/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -237,7 +245,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-volumemount-inconsistent-path" {
   tmp=$(split_files "policy/ocp/bestpractices/container-volumemount-inconsistent-path/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -250,7 +258,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/container-volumemount-missing" {
   tmp=$(split_files "policy/ocp/bestpractices/container-volumemount-missing/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -263,7 +271,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/pod-hostnetwork" {
   tmp=$(split_files "policy/ocp/bestpractices/pod-hostnetwork/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -276,7 +284,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/pod-replicas-below-one" {
   tmp=$(split_files "policy/ocp/bestpractices/pod-replicas-below-one/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
@@ -289,7 +297,7 @@ load test_helper/redhatcop-bats-library/load
 @test "policy/ocp/bestpractices/pod-replicas-not-odd" {
   tmp=$(split_files "policy/ocp/bestpractices/pod-replicas-not-odd/test_data/integration")
 
-  cmd="oc create -f ${tmp}"
+  cmd="oc create -f ${tmp} -n ${project_name}"
   run ${cmd}
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"

--- a/_test/namespace-under-test.yml
+++ b/_test/namespace-under-test.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: project-under-test
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      redhat-cop.github.com/gatekeeper-active: 'true'
+    name: "${PROJECT_NAME}"
+parameters:
+- name: PROJECT_NAME
+  required: true

--- a/gatekeeper/gatekeeper-template-manager.yml
+++ b/gatekeeper/gatekeeper-template-manager.yml
@@ -1,0 +1,59 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gatekeeper-constraintsmanager-role
+rules:
+- apiGroups:
+    - constraints.gatekeeper.sh
+  resources:
+    - '*'
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - status.gatekeeper.sh
+  resources:
+    - '*'
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - templates.gatekeeper.sh
+  resources:
+    - constrainttemplates
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - templates.gatekeeper.sh
+  resources:
+    - constrainttemplates/finalizers
+  verbs:
+    - delete
+    - get
+    - patch
+    - update
+- apiGroups:
+    - templates.gatekeeper.sh
+  resources:
+    - constrainttemplates/status
+  verbs:
+    - get
+    - patch
+    - update


### PR DESCRIPTION
#### What is this PR About?
Adds a label to all control-plane based namespaces so OPA doesn't audit / deny them.
Create a unique namespace for the tests to be deployed into

CC @springdo @ckavili 

#### How do we test this?
Run the integration tests:
```
_test/deploy-gatekeeper.sh deploy_gatekeeper
_test/deploy-gatekeeper.sh deploy_constraints
bats _test/gatekeeper-integrationtests.sh
```

cc: @redhat-cop/rego-policies
