### PR TITLE
Added validation step for integration data

### DIFF
--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -9,6 +9,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Validate integration test data via kubeval
+        uses: garethahealy/github-actions/confbatstest@kubeval
+        with:
+          raw: find policy/* -regex '.*test_data\/integration\/.*$' -exec kubeval --openshift --strict --skip-kinds ServiceMonitor {} \;
+
       - name: Generate konstraint docs
         uses: garethahealy/github-actions/confbatstest@conftest-raw
         with:

--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -10,12 +10,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Validate integration test data via kubeval
-        uses: garethahealy/github-actions/confbatstest@kubeval
+        uses: redhat-cop/github-actions/confbatstest@master
         with:
           raw: find policy/* -regex '.*test_data\/integration\/.*$' -exec kubeval --openshift --strict --skip-kinds ServiceMonitor {} \;
 
       - name: Generate konstraint docs
-        uses: garethahealy/github-actions/confbatstest@conftest-raw
+        uses: redhat-cop/github-actions/confbatstest@master
         with:
           raw: konstraint doc -o POLICIES.md
 


### PR DESCRIPTION
#### What is this PR About?
kubeval can be used to check the yaml/json is valid against the API. Its a safety check so that no one adds in a policy with invalid data input.

#### How do we test this?
Action stays green

cc: @redhat-cop/rego-policies
