### PR TITLE
Split out the docs ci bits into its own pipeline

### DIFF
--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -1,4 +1,4 @@
-name: Validate
+name: Run conftest
 
 on: [push, pull_request]
 
@@ -13,23 +13,6 @@ jobs:
         uses: redhat-cop/github-actions/confbatstest@master
         with:
           raw: find policy/* -regex '.*test_data\/integration\/.*$' -exec kubeval --openshift --strict --skip-kinds ServiceMonitor {} \;
-
-      - name: Generate konstraint docs
-        uses: redhat-cop/github-actions/confbatstest@master
-        with:
-          raw: konstraint doc -o POLICIES.md
-
-      - name: Check if there are changes to POLICIES.md
-        id: changes
-        uses: UnicornGlobal/has-changes-action@master
-        with:
-          pathspec: POLICIES.md
-
-      - name: Fail if POLICIES.md changes found
-        if: steps.changes.outputs.changed == 1
-        run: |
-          echo "Uncommited changes to POLICIES.md exist. Failing."
-          exit 0
 
       - name: Conftest
         uses: redhat-cop/github-actions/confbatstest@master

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,27 @@
+name: Check POLICIES.md is up-to-date
+
+on: [push, pull_request]
+
+jobs:
+  konstraint_doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate konstraint docs
+        uses: redhat-cop/github-actions/confbatstest@master
+        with:
+          raw: konstraint doc -o POLICIES.md
+
+      - name: Check if there are changes to POLICIES.md
+        id: changes
+        uses: UnicornGlobal/has-changes-action@master
+        with:
+          pathspec: POLICIES.md
+
+      - name: Fail if POLICIES.md changes found
+        if: steps.changes.outputs.changed == 1
+        run: |
+          echo "Uncommited changes to POLICIES.md exist. Failing."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Validate](https://github.com/redhat-cop/rego-policies/workflows/Validate/badge.svg)
+![Run conftest](https://github.com/redhat-cop/rego-policies/workflows/Run%20conftest/badge.svg)
 
 # rego-policies
 [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) policies collection.


### PR DESCRIPTION
#### What is this PR About?
As konstraint has changed the docs output a few times over the past week, it causes the CI to fail, which then stalls PRs. Thought it would be a good idea to split out the testing of the policies and whether the docs need regenerating into two flows.

#### How do we test this?
Policies == green
Docs == red (needs a PR to fix)

cc: @redhat-cop/rego-policies
