### PR TITLE
Updated kinds annotation to be lower case

### DIFF
--- a/policy/combine/namespace-has-networkpolicy/src.rego
+++ b/policy/combine/namespace-has-networkpolicy/src.rego
@@ -3,7 +3,7 @@ package combine.namespace_has_networkpolicy
 import data.lib.konstraint
 
 # violation: Check if a Namespace has a networking.k8s.io/v1:NetworkPolicy
-# @Kinds core/Namespace networking.k8s.io/NetworkPolicy
+# @kinds core/Namespace networking.k8s.io/NetworkPolicy
 violation[msg] {
   manifests := input[_]
   some i

--- a/policy/ocp/bestpractices/common-k8s-labels-notset/src.rego
+++ b/policy/ocp/bestpractices/common-k8s-labels-notset/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check if all workload related kinds contain labels as suggested by https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet core/Service route.openshift.io/Route
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet core/Service route.openshift.io/Route
 violation[msg] {
   openshift.is_all_kind
 

--- a/policy/ocp/bestpractices/container-env-maxmemory-notset/src.rego
+++ b/policy/ocp/bestpractices/container-env-maxmemory-notset/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds have the CONTAINER_MAX_MEMORY env set using the downward api
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-image-latest/src.rego
+++ b/policy/ocp/bestpractices/container-image-latest/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds are not using the latest tag for their image
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-java-xmx-set/src.rego
+++ b/policy/ocp/bestpractices/container-java-xmx-set/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds do not set the Java Xmx option
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-labelkey-inconsistent/src.rego
+++ b/policy/ocp/bestpractices/container-labelkey-inconsistent/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds have consistent key names for their labels
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-liveness-readinessprobe-equal/src.rego
+++ b/policy/ocp/bestpractices/container-liveness-readinessprobe-equal/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds have not set their probes to be the same
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-livenessprobe-notset/src.rego
+++ b/policy/ocp/bestpractices/container-livenessprobe-notset/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds have their liveness prob set
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-readinessprobe-notset/src.rego
+++ b/policy/ocp/bestpractices/container-readinessprobe-notset/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds have their readiness prob set
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-resources-limits-cpu-set/src.rego
+++ b/policy/ocp/bestpractices/container-resources-limits-cpu-set/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds do not set limits for CPU
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-resources-limits-memory-greater-than/src.rego
+++ b/policy/ocp/bestpractices/container-resources-limits-memory-greater-than/src.rego
@@ -5,7 +5,7 @@ import data.lib.memory
 import data.lib.openshift
 
 # violation: Check workload kinds limits for memory is not greater than an upper bound
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-resources-limits-memory-notset/src.rego
+++ b/policy/ocp/bestpractices/container-resources-limits-memory-notset/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds has set their limits for memory
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-resources-memoryunit-incorrect/src.rego
+++ b/policy/ocp/bestpractices/container-resources-memoryunit-incorrect/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds memory limits and requests unit is valid
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-resources-requests-cpuunit-incorrect/src.rego
+++ b/policy/ocp/bestpractices/container-resources-requests-cpuunit-incorrect/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds cpu requests unit is valid
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-resources-requests-memory-greater-than/src.rego
+++ b/policy/ocp/bestpractices/container-resources-requests-memory-greater-than/src.rego
@@ -5,7 +5,7 @@ import data.lib.memory
 import data.lib.openshift
 
 # violation: Check workload kinds requests for memory is not greater than an upper bound
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-secret-mounted-envs/src.rego
+++ b/policy/ocp/bestpractices/container-secret-mounted-envs/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds do not have secrets mounted as envs
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-volumemount-inconsistent-path/src.rego
+++ b/policy/ocp/bestpractices/container-volumemount-inconsistent-path/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds have consistent paths for their volume mounts
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/container-volumemount-missing/src.rego
+++ b/policy/ocp/bestpractices/container-volumemount-missing/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds does not specify a volume without a corresponding volume mount
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/deploymentconfig-triggers-notset/src.rego
+++ b/policy/ocp/bestpractices/deploymentconfig-triggers-notset/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check if a DeploymentConfig has 'spec.triggers' set
-# @Kinds apps.openshift.io/DeploymentConfig
+# @kinds apps.openshift.io/DeploymentConfig
 violation[msg] {
   openshift.is_deploymentconfig
 

--- a/policy/ocp/bestpractices/pod-hostnetwork/src.rego
+++ b/policy/ocp/bestpractices/pod-hostnetwork/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds has 'spec.hostNetwork' set
-# @Kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
+# @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/StatefulSet
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/pod-replicas-below-one/src.rego
+++ b/policy/ocp/bestpractices/pod-replicas-below-one/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds has replicas <= 1
-# @Kinds apps.openshift.io/DeploymentConfig apps/Deployment
+# @kinds apps.openshift.io/DeploymentConfig apps/Deployment
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/pod-replicas-not-odd/src.rego
+++ b/policy/ocp/bestpractices/pod-replicas-not-odd/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.openshift
 
 # violation: Check workload kinds has replicas not odd
-# @Kinds apps.openshift.io/DeploymentConfig apps/Deployment
+# @kinds apps.openshift.io/DeploymentConfig apps/Deployment
 violation[msg] {
   openshift.is_workload_kind
 

--- a/policy/ocp/bestpractices/rolebinding-roleref-apigroup-notset/src.rego
+++ b/policy/ocp/bestpractices/rolebinding-roleref-apigroup-notset/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.kubernetes
 
 # violation: Check if a RoleBinding has 'roleRef.apiGroup' set
-# @Kinds rbac.authorization.k8s.io/RoleBinding
+# @kinds rbac.authorization.k8s.io/RoleBinding
 violation[msg] {
   kubernetes.is_rolebinding
 

--- a/policy/ocp/bestpractices/rolebinding-roleref-kind-notset/src.rego
+++ b/policy/ocp/bestpractices/rolebinding-roleref-kind-notset/src.rego
@@ -4,7 +4,7 @@ import data.lib.konstraint
 import data.lib.kubernetes
 
 # violation: Check if a RoleBinding has 'roleRef.kind' set
-# @Kinds rbac.authorization.k8s.io/RoleBinding
+# @kinds rbac.authorization.k8s.io/RoleBinding
 violation[msg] {
   kubernetes.is_rolebinding
 

--- a/policy/ocp/deprecated/3_11/buildconfig-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/buildconfig-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp3_11.buildconfig_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated v1 apiVersion. OCP4.x expects build.openshift.io/v1
-# @Kinds v1/BuildConfig
+# @kinds v1/BuildConfig
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "v1"

--- a/policy/ocp/deprecated/3_11/deploymentconfig-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/deploymentconfig-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp3_11.deploymentconfig_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated v1 apiVersion. OCP4.x expects apps.openshift.io/v1
-# @Kinds v1/DeploymentConfig
+# @kinds v1/DeploymentConfig
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "v1"

--- a/policy/ocp/deprecated/3_11/imagestream-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/imagestream-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp3_11.imagestream_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated v1 apiVersion. OCP4.x expects image.openshift.io/v1
-# @Kinds v1/ImageStream
+# @kinds v1/ImageStream
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "v1"

--- a/policy/ocp/deprecated/3_11/projectrequest-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/projectrequest-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp3_11.projectrequest_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated v1 apiVersion. OCP4.x expects project.openshift.io/v1
-# @Kinds v1/ProjectRequest
+# @kinds v1/ProjectRequest
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "v1"

--- a/policy/ocp/deprecated/3_11/rolebinding-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/rolebinding-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp3_11.rolebinding_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated v1 apiVersion. OCP4.x expects rbac.authorization.k8s.io/v1
-# @Kinds v1/RoleBinding
+# @kinds v1/RoleBinding
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "v1"

--- a/policy/ocp/deprecated/3_11/route-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/route-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp3_11.route_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated v1 apiVersion. OCP4.x expects route.openshift.io/v1
-# @Kinds v1/Route
+# @kinds v1/Route
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "v1"

--- a/policy/ocp/deprecated/3_11/securitycontextconstraints-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/securitycontextconstraints-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp3_11.securitycontextconstraints_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated v1 apiVersion. OCP4.x expects security.openshift.io/v1
-# @Kinds v1/SecurityContextConstraints
+# @kinds v1/SecurityContextConstraints
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "v1"

--- a/policy/ocp/deprecated/3_11/template-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/template-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp3_11.template_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated v1 apiVersion. OCP4.x expects template.openshift.io/v1
-# @Kinds v1/Template
+# @kinds v1/Template
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "v1"

--- a/policy/ocp/deprecated/4_1/buildconfig-custom-strategy/src.rego
+++ b/policy/ocp/deprecated/4_1/buildconfig-custom-strategy/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp4_1.buildconfig_custom_strategy
 import data.lib.konstraint
 
 # violation: Check if 'exposeDockerSocket' is set on a BuildConfig. See: https://docs.openshift.com/container-platform/4.1/release_notes/ocp-4-1-release-notes.html#ocp-41-deprecated-features
-# @Kinds build.openshift.io/BuildConfig
+# @kinds build.openshift.io/BuildConfig
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "build.openshift.io/v1"

--- a/policy/ocp/deprecated/4_2/authorization-openshift/src.rego
+++ b/policy/ocp/deprecated/4_2/authorization-openshift/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp4_2.authorization_openshift
 import data.lib.konstraint
 
 # violation: Check for deprecated authorization.openshift.io apiVersion. >= OCP4.2 expects rbac.authorization.k8s.io/v1. See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
-# @Kinds authorization.openshift.io/ClusterRole authorization.openshift.io/ClusterRoleBinding authorization.openshift.io/Role authorization.openshift.io/RoleBinding
+# @kinds authorization.openshift.io/ClusterRole authorization.openshift.io/ClusterRoleBinding authorization.openshift.io/Role authorization.openshift.io/RoleBinding
 violation[msg] {
   obj := konstraint.object
   contains(lower(obj.apiVersion), "authorization.openshift.io")

--- a/policy/ocp/deprecated/4_2/automationbroker-v1alpha1/src.rego
+++ b/policy/ocp/deprecated/4_2/automationbroker-v1alpha1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp4_2.automationbroker_v1alpha1
 import data.lib.konstraint
 
 # violation: Check for deprecated automationbroker.io/v1alpha1 apiVersion. See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
-# @Kinds automationbroker.io/Bundle automationbroker.io/BundleBinding automationbroker.io/BundleInstance
+# @kinds automationbroker.io/Bundle automationbroker.io/BundleBinding automationbroker.io/BundleInstance
 violation[msg] {
   obj := konstraint.object
   contains(lower(obj.apiVersion), "automationbroker.io/v1alpha1")

--- a/policy/ocp/deprecated/4_2/catalogsourceconfigs-v1/src.rego
+++ b/policy/ocp/deprecated/4_2/catalogsourceconfigs-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp4_2.catalogsourceconfigs_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated operators.coreos.com/v1 apiVersion. See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
-# @Kinds operators.coreos.com/CatalogSourceConfigs
+# @kinds operators.coreos.com/CatalogSourceConfigs
 violation[msg] {
   obj := konstraint.object
   contains(lower(obj.apiVersion), "operators.coreos.com/v1")

--- a/policy/ocp/deprecated/4_2/catalogsourceconfigs-v2/src.rego
+++ b/policy/ocp/deprecated/4_2/catalogsourceconfigs-v2/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp4_2.catalogsourceconfigs_v2
 import data.lib.konstraint
 
 # violation: Check for deprecated operators.coreos.com/v2 apiVersion. See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
-# @Kinds operators.coreos.com/CatalogSourceConfigs
+# @kinds operators.coreos.com/CatalogSourceConfigs
 violation[msg] {
   obj := konstraint.object
   contains(lower(obj.apiVersion), "operators.coreos.com/v2")

--- a/policy/ocp/deprecated/4_2/operatorsources-v1/src.rego
+++ b/policy/ocp/deprecated/4_2/operatorsources-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp4_2.operatorsources_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated operators.coreos.com/v1 apiVersion. See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
-# @Kinds operators.coreos.com/OperatorSource
+# @kinds operators.coreos.com/OperatorSource
 violation[msg] {
   obj := konstraint.object
   contains(lower(obj.apiVersion), "operators.coreos.com/v1")

--- a/policy/ocp/deprecated/4_2/osb-v1/src.rego
+++ b/policy/ocp/deprecated/4_2/osb-v1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp4_2.osb_v1
 import data.lib.konstraint
 
 # violation: Check for deprecated osb.openshift.io/v1 apiVersion. See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
-# @Kinds osb.openshift.io/TemplateServiceBroker osb.openshift.io/AutomationBroker
+# @kinds osb.openshift.io/TemplateServiceBroker osb.openshift.io/AutomationBroker
 violation[msg] {
   obj := konstraint.object
   contains(lower(obj.apiVersion), "osb.openshift.io/v1")

--- a/policy/ocp/deprecated/4_2/servicecatalog-v1beta1/src.rego
+++ b/policy/ocp/deprecated/4_2/servicecatalog-v1beta1/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp4_2.servicecatalog_v1beta1
 import data.lib.konstraint
 
 # violation: Check for deprecated servicecatalog.k8s.io/v1beta1 apiVersion. See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
-# @Kinds servicecatalog.k8s.io/ClusterServiceBroker servicecatalog.k8s.io/ClusterServiceClass servicecatalog.k8s.io/ClusterServicePlan servicecatalog.k8s.io/ServiceInstance servicecatalog.k8s.io/ServiceBinding
+# @kinds servicecatalog.k8s.io/ClusterServiceBroker servicecatalog.k8s.io/ClusterServiceClass servicecatalog.k8s.io/ClusterServicePlan servicecatalog.k8s.io/ServiceInstance servicecatalog.k8s.io/ServiceBinding
 violation[msg] {
   obj := konstraint.object
   contains(lower(obj.apiVersion), "servicecatalog.k8s.io/v1beta1")

--- a/policy/ocp/deprecated/4_3/buildconfig-jenkinspipeline-strategy/src.rego
+++ b/policy/ocp/deprecated/4_3/buildconfig-jenkinspipeline-strategy/src.rego
@@ -3,7 +3,7 @@ package ocp.deprecated.ocp4_3.buildconfig_jenkinspipeline_strategy
 import data.lib.konstraint
 
 # violation: Check if 'jenkinsPipelineStrategy' is set on a BuildConfig. See: https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html#ocp-4-3-deprecated-features
-# @Kinds build.openshift.io/BuildConfig
+# @kinds build.openshift.io/BuildConfig
 violation[msg] {
   obj := konstraint.object
   lower(obj.apiVersion) == "build.openshift.io/v1"

--- a/policy/ocp/requiresinventory/deployment-has-matching-poddisruptionbudget/src.rego
+++ b/policy/ocp/requiresinventory/deployment-has-matching-poddisruptionbudget/src.rego
@@ -3,7 +3,7 @@ package ocp.requiresinventory.deployment_has_matching_poddisruptionbudget
 import data.lib.konstraint
 
 # violation: Check if a Deployment has a matching policy/v1beta1:PodDisruptionBudget, via 'spec.template.metadata.labels'
-# @Kinds apps/Deployment
+# @kinds apps/Deployment
 violation[msg] {
   konstraint.is_deployment
 

--- a/policy/ocp/requiresinventory/deployment-has-matching-pvc/src.rego
+++ b/policy/ocp/requiresinventory/deployment-has-matching-pvc/src.rego
@@ -3,7 +3,7 @@ package ocp.requiresinventory.deployment_has_matching_pvc
 import data.lib.konstraint
 
 # violation: Check if a Deployment has 'spec.template.spec.volumes.persistentVolumeClaim' set, there is a matching v1:PersistentVolumeClaim
-# @Kinds apps/Deployment
+# @kinds apps/Deployment
 violation[msg] {
   konstraint.is_deployment
 

--- a/policy/ocp/requiresinventory/deployment-has-matching-service/src.rego
+++ b/policy/ocp/requiresinventory/deployment-has-matching-service/src.rego
@@ -3,7 +3,7 @@ package ocp.requiresinventory.deployment_has_matching_service
 import data.lib.konstraint
 
 # violation: Check if a Deployment has a matching v1:Service, via 'spec.template.metadata.labels'
-# @Kinds apps/Deployment
+# @kinds apps/Deployment
 violation[msg] {
   konstraint.is_deployment
 

--- a/policy/ocp/requiresinventory/deployment-has-matching-serviceaccount/src.rego
+++ b/policy/ocp/requiresinventory/deployment-has-matching-serviceaccount/src.rego
@@ -3,7 +3,7 @@ package ocp.requiresinventory.deployment_has_matching_serviceaccount
 import data.lib.konstraint
 
 # violation: Check if a Deployment has 'spec.serviceAccountName' set, there is a matching v1:ServiceAccount
-# @Kinds apps/Deployment
+# @kinds apps/Deployment
 violation[msg] {
   konstraint.is_deployment
 

--- a/policy/ocp/requiresinventory/service-has-matching-servicemonitor/src.rego
+++ b/policy/ocp/requiresinventory/service-has-matching-servicemonitor/src.rego
@@ -3,7 +3,7 @@ package ocp.requiresinventory.service_has_matching_servicenonitor
 import data.lib.konstraint
 
 # violation: Check if a Service has a matching monitoring.coreos.com/v1:ServiceMonitor, via 'spec.selector'
-# @Kinds core/Service
+# @kinds core/Service
 violation[msg] {
   konstraint.is_service
 

--- a/policy/podman/history/contains-layer/src.rego
+++ b/policy/podman/history/contains-layer/src.rego
@@ -1,7 +1,7 @@
 package podman.history.contains_layer
 
 # violation: Check the image contains a specific SHA in its history
-# @Kinds redhat-cop.github.com/PodmanHistory
+# @kinds redhat-cop.github.com/PodmanHistory
 violation[msg] {
   lower(input.apiVersion) == "redhat-cop.github.com/v1"
   lower(input.kind) == "podmanhistory"

--- a/policy/podman/images/image-size-not-greater-than/src.rego
+++ b/policy/podman/images/image-size-not-greater-than/src.rego
@@ -3,7 +3,7 @@ package podman.images.image_size_not_greater_than
 import data.lib.memory
 
 # violation: Check the image size is not greater than a specific value
-# @Kinds redhat-cop.github.com/PodmanImages
+# @kinds redhat-cop.github.com/PodmanImages
 violation[msg] {
   lower(input.apiVersion) == "redhat-cop.github.com/v1"
   lower(input.kind) == "podmanimages"


### PR DESCRIPTION
#### What is this PR About?
Konstraint now expects the kind annotation to be lowercase. 

#### How do we test this?
Check the generated `constraint.yaml` includes the kinds key. i.e.:

```
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: ContainerVolumemountInconsistentPath
metadata:
  name: containervolumemountinconsistentpath
spec:
  match:
    kinds:
    - apiGroups:
      - apps.openshift.io
      - apps
      kinds:
      - DeploymentConfig
      - DaemonSet
      - Deployment
      - StatefulSet
```

cc: @redhat-cop/rego-policies
