### PR TITLE
adding namespace-has-resourcequota policy

### DIFF
--- a/_test/conftest-unittests.sh
+++ b/_test/conftest-unittests.sh
@@ -39,6 +39,18 @@ setup_file() {
   [ "${lines[2]}" = "" ]
 }
 
+@test "policy/combine/namespace-has-resourcequota" {
+  tmp=$(split_files "policy/combine/namespace-has-resourcequota/test_data/unit")
+
+  cmd="conftest test ${tmp} --output tap --combine --namespace combine.namespace_has_resourcequota"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+  [ "${lines[1]}" = "not ok 1 - Combined - Namespace/foo does not have a core/v1:ResourceQuota. See: https://docs.openshift.com/container-platform/4.5/applications/quotas/quotas-setting-per-project.html" ]
+  [ "${lines[2]}" = "" ]
+}
+
 ####################
 # ocp/bestpractices
 ####################

--- a/policy/combine/namespace-has-resourcequota/src.rego
+++ b/policy/combine/namespace-has-resourcequota/src.rego
@@ -1,0 +1,32 @@
+package combine.namespace_has_resourcequota
+
+import data.lib.konstraint
+
+# @title Namespace has a ResourceQuota
+#
+# With ResourceQuotas, you can limit the total resource consumption of all containers inside a Namespace.
+# Defining a resource quota for a namespace limits the total amount of CPU, memory or storage resources
+# that can be consumed by all containers belonging to that namespace. You can also set quotas for other 
+# Kubernetes objects such as the number of Pods in the current namespace.
+# See: Namespace limits -> https://learnk8s.io/production-best-practices#governance
+#
+# @kinds core/Namespace core/ResourceQuota
+violation[msg] {
+  manifests := input[_]
+  some i
+
+  lower(manifests[i].apiVersion) == "v1"
+  lower(manifests[i].kind) == "namespace"
+  namespace := manifests[i]
+
+  not namespace_has_resourcequota(manifests)
+
+  msg := konstraint.format(sprintf("%s/%s does not have a core/v1:ResourceQuota. See: https://docs.openshift.com/container-platform/4.5/applications/quotas/quotas-setting-per-project.html", [namespace.kind, namespace.metadata.name]))
+}
+
+namespace_has_resourcequota(manifests) {
+  current := manifests[_]
+
+  lower(current.apiVersion) == "v1"
+  lower(current.kind) == "resourcequota"
+}

--- a/policy/combine/namespace-has-resourcequota/test_data/unit/list.yml
+++ b/policy/combine/namespace-has-resourcequota/test_data/unit/list.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: foo
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: conftestneedsaseconditem


### PR DESCRIPTION
#### What is this PR About?
Adds `namespace-has-resourcequota`. Closes #55 

#### Check list
- [x] Have you created a test case in `_test/conftest-unittests.sh`
- [ ] Have you created a test case in `_test/opa-profile.sh`
- [ ] Have you created a test case in `_test/gatekeeper-integrationtests.sh`
- [x] Have you followed the TESTING.md doc? If not, please provide commands/steps to test this PR.
- [x] Have you re-generated `POLICIES.md`

The other namespace-has-* policy didn't have a test case in _test/opa-profile.sh or _test/gatekeeper-integrationtests.sh, so I didn't add tests there since this one is similar.

cc: @redhat-cop/rego-policies
