### PR TITLE
SCC RBAC implementation

### DIFF
--- a/_test/deploy-gatekeeper.sh
+++ b/_test/deploy-gatekeeper.sh
@@ -39,7 +39,8 @@ deploy_gatekeeper() {
 
   echo ""
   echo "Patching gatekeeper to work on OCP..."
-  oc adm policy add-scc-to-user anyuid system:serviceaccount:gatekeeper-system:gatekeeper-admin
+  oc create clusterrole allow-anyuid-scc --verb=use --resource=securitycontextconstraints.security.openshift.io --resource-name=anyuid
+  oc create rolebinding gatekeeper-anyuid-scc --serviceaccount=gatekeeper-system:gatekeeper-admin --clusterrole=allow-anyuid-scc -n gatekeeper-system
   oc patch Deployment/gatekeeper-controller-manager --type json -p='[{"op": "remove", "path": "/spec/template/metadata/annotations"}]' -n gatekeeper-system
 
   echo ""


### PR DESCRIPTION
#### What is this PR About?

Removes directly modifying the `anyuid` scc to instead use RBAC to gain access

cc: @redhat-cop/rego-policies
