### PR TITLE
Updated conftest ci to use central

### DIFF
--- a/.github/workflows/opa-profile.yaml
+++ b/.github/workflows/opa-profile.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Opa eval --profile
-        uses: garethahealy/github-actions/confbatstest@master
+        uses: redhat-cop/github-actions/confbatstest@master
         with:
           tests: _test/opa-profile.sh
           policies: '[{"name": "deprek8ion", "url":"github.com/swade1987/deprek8ion.git//policies"}]'


### PR DESCRIPTION
#### What is this PR About?
Changes to support opa in the ci got merged, so moving the ci to central again.

cc: @redhat-cop/rego-policies
