### PR TITLE
Added label selector for java related policies

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -195,6 +195,7 @@ import data.lib.openshift
 violation[msg] {
   container := openshift.containers[_]
 
+  konstraint_core.labels["redhat-cop.github.com/technology"] == "java"
   not is_env_max_memory_set(container)
 
   msg := konstraint_core.format_with_id(sprintf("%s/%s: container '%s' does not have an env named 'CONTAINER_MAX_MEMORY' which is used by the Red Hat base images to calculate memory. See: https://docs.openshift.com/container-platform/4.6/nodes/clusters/nodes-cluster-resource-configure.html and https://github.com/jboss-openshift/cct_module/blob/master/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options", [konstraint_core.kind, konstraint_core.name, container.name]), "RHCOP-OCP_BESTPRACT-00002")
@@ -289,6 +290,7 @@ import data.lib.openshift
 violation[msg] {
   container := openshift.containers[_]
 
+  konstraint_core.labels["redhat-cop.github.com/technology"] == "java"
   container_opts_contains_xmx(container)
 
   msg := konstraint_core.format_with_id(sprintf("%s/%s: container '%s' contains -Xmx in either, command, args or env. Instead, it is suggested you use the downward API to set the env 'CONTAINER_MAX_MEMORY'", [konstraint_core.kind, konstraint_core.name, container.name]), "RHCOP-OCP_BESTPRACT-00005")

--- a/_test/all-namespaces/ocp/bestpractices/all.yml
+++ b/_test/all-namespaces/ocp/bestpractices/all.yml
@@ -82,6 +82,7 @@ objects:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: shouldneverfire-${NAME}
   spec:
     replicas: 3
@@ -157,6 +158,7 @@ objects:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: shouldneverfire${NAME}
   spec:
     replicas: 3

--- a/policy/ocp/bestpractices/container-env-maxmemory-notset/src.rego
+++ b/policy/ocp/bestpractices/container-env-maxmemory-notset/src.rego
@@ -13,6 +13,7 @@ import data.lib.openshift
 violation[msg] {
   container := openshift.containers[_]
 
+  konstraint_core.labels["redhat-cop.github.com/technology"] == "java"
   not is_env_max_memory_set(container)
 
   msg := konstraint_core.format_with_id(sprintf("%s/%s: container '%s' does not have an env named 'CONTAINER_MAX_MEMORY' which is used by the Red Hat base images to calculate memory. See: https://docs.openshift.com/container-platform/4.6/nodes/clusters/nodes-cluster-resource-configure.html and https://github.com/jboss-openshift/cct_module/blob/master/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options", [konstraint_core.kind, konstraint_core.name, container.name]), "RHCOP-OCP_BESTPRACT-00002")

--- a/policy/ocp/bestpractices/container-env-maxmemory-notset/test_data/integration/list.yml
+++ b/policy/ocp/bestpractices/container-env-maxmemory-notset/test_data/integration/list.yml
@@ -12,6 +12,7 @@ items:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: nodownwardmemoryenv
   spec:
     replicas: 3
@@ -73,6 +74,7 @@ items:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: nodownwardmemoryenv
   spec:
     replicas: 3

--- a/policy/ocp/bestpractices/container-env-maxmemory-notset/test_data/unit/list.yml
+++ b/policy/ocp/bestpractices/container-env-maxmemory-notset/test_data/unit/list.yml
@@ -5,6 +5,8 @@ items:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
+    labels:
+      redhat-cop.github.com/technology: java
     name: nodownwardmemoryenv
   spec:
     template:
@@ -14,6 +16,8 @@ items:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
+    labels:
+      redhat-cop.github.com/technology: java
     name: nodownwardmemoryenv
   spec:
     template:

--- a/policy/ocp/bestpractices/container-java-xmx-set/src.rego
+++ b/policy/ocp/bestpractices/container-java-xmx-set/src.rego
@@ -12,6 +12,7 @@ import data.lib.openshift
 violation[msg] {
   container := openshift.containers[_]
 
+  konstraint_core.labels["redhat-cop.github.com/technology"] == "java"
   container_opts_contains_xmx(container)
 
   msg := konstraint_core.format_with_id(sprintf("%s/%s: container '%s' contains -Xmx in either, command, args or env. Instead, it is suggested you use the downward API to set the env 'CONTAINER_MAX_MEMORY'", [konstraint_core.kind, konstraint_core.name, container.name]), "RHCOP-OCP_BESTPRACT-00005")

--- a/policy/ocp/bestpractices/container-java-xmx-set/test_data/integration/list.yml
+++ b/policy/ocp/bestpractices/container-java-xmx-set/test_data/integration/list.yml
@@ -12,6 +12,7 @@ items:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: xmxviacommand
   spec:
     replicas: 3
@@ -79,6 +80,7 @@ items:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: xmxviaargs
   spec:
     replicas: 3
@@ -146,6 +148,7 @@ items:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: xmxviaenv
   spec:
     replicas: 3
@@ -214,6 +217,7 @@ items:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: xmxviacommand
   spec:
     replicas: 3
@@ -275,6 +279,7 @@ items:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: xmxviaargs
   spec:
     replicas: 3
@@ -336,6 +341,7 @@ items:
       app.kubernetes.io/component: FooBar
       app.kubernetes.io/part-of: Foo
       app.kubernetes.io/managed-by: Bar
+      redhat-cop.github.com/technology: java
     name: xmxviaenv
   spec:
     replicas: 3

--- a/policy/ocp/bestpractices/container-java-xmx-set/test_data/unit/list.yml
+++ b/policy/ocp/bestpractices/container-java-xmx-set/test_data/unit/list.yml
@@ -5,6 +5,8 @@ items:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
+    labels:
+      redhat-cop.github.com/technology: java
     name: xmxviacommand
   spec:
     template:
@@ -15,6 +17,8 @@ items:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
+    labels:
+      redhat-cop.github.com/technology: java
     name: xmxviaargs
   spec:
     template:
@@ -25,6 +29,8 @@ items:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
+    labels:
+      redhat-cop.github.com/technology: java
     name: xmxviaenv
   spec:
     template:
@@ -37,6 +43,8 @@ items:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
+    labels:
+      redhat-cop.github.com/technology: java
     name: xmxviacommand
   spec:
     template:
@@ -47,6 +55,8 @@ items:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
+    labels:
+      redhat-cop.github.com/technology: java
     name: xmxviaargs
   spec:
     template:
@@ -57,6 +67,8 @@ items:
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
+    labels:
+      redhat-cop.github.com/technology: java
     name: xmxviaenv
   spec:
     template:


### PR DESCRIPTION
#### What is this PR About?
The two java memory policies currently target all deployments. Added a hint so they only target ones which the user says is java related.

#### Check list
- [x] Have you created a test case in `_test/conftest-unittests.sh`
- [x] Have you created a test case in `_test/opa-profile.sh`
- [x] Have you created a test case in `_test/gatekeeper-integrationtests.sh`
- [x] Have you followed the TESTING.md doc? If not, please provide commands/steps to test this PR.
- [x] Have you re-generated `POLICIES.md`

cc: @redhat-cop/rego-policies
