### PR TITLE
 Added check to see if policy id is in disabled label of namespace

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -156,6 +156,7 @@ import data.lib.konstraint.core as konstraint_core
 import data.lib.openshift
 
 violation[msg] {
+  openshift.is_policy_active("RHCOP-OCP_BESTPRACT-00001")
   openshift.is_pod_or_networking
 
   not is_common_labels_set(konstraint_core.resource.metadata)

--- a/_test/namespace-under-test.yml
+++ b/_test/namespace-under-test.yml
@@ -8,8 +8,11 @@ objects:
   kind: Namespace
   metadata:
     labels:
-      redhat-cop.github.com/gatekeeper-active: 'true'
+      redhat-cop.github.com/gatekeeper-active: "true"
+      redhat-cop.github.com/gatekeeper-disabled-policies: "${DISABLED}"
     name: "${PROJECT_NAME}"
 parameters:
 - name: PROJECT_NAME
   required: true
+- name: DISABLED
+  value: none

--- a/policy/lib/openshift.rego
+++ b/policy/lib/openshift.rego
@@ -39,3 +39,29 @@ is_pod_or_networking {
 is_pod_or_networking {
     is_route
 }
+
+is_policy_active(policyId) {
+    not konstraint_core.is_gatekeeper
+}
+
+is_policy_active(policyId) {
+    konstraint_core.is_gatekeeper
+
+    disabledpolicies := namespace_disabled_policies_label
+    not label_contains(disabledpolicies, policyId)
+}
+
+label_contains(disabledpolicies, policyId) {
+    policyId == disabledpolicies[_]
+}
+
+namespace_disabled_policies_label = disabledpolicies {
+    namepace := data.inventory.cluster["v1"].Namespace[konstraint_core.resource.metadata.namespace]
+    label := namepace.metadata.labels["redhat-cop.github.com/gatekeeper-disabled-policies"]
+    disabledpolicies := split(label, ",")
+}
+
+namespace_disabled_policies_label = [""] {
+    namepace := data.inventory.cluster["v1"].Namespace[konstraint_core.resource.metadata.namespace]
+    not namepace.metadata.labels["redhat-cop.github.com/gatekeeper-disabled-policies"]
+}

--- a/policy/ocp/bestpractices/common-k8s-labels-notset/src.rego
+++ b/policy/ocp/bestpractices/common-k8s-labels-notset/src.rego
@@ -10,6 +10,7 @@ import data.lib.openshift
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob core/Service route.openshift.io/Route
 violation[msg] {
+  openshift.is_policy_active("RHCOP-OCP_BESTPRACT-00001")
   openshift.is_pod_or_networking
 
   not is_common_labels_set(konstraint_core.resource.metadata)


### PR DESCRIPTION
#### What is this PR About?
As per subject.

The general idea is; if a namespace has the label `redhat-cop.github.com/gatekeeper-disabled-policies` which contains the policy id, don't fire the policy.

Since its just a string, the label could include multiple comma-separated policy ids.

#### Check list
- [x] Have you created a test case in `_test/conftest-unittests.sh`
- [x] Have you created a test case in `_test/opa-profile.sh`
- [x] Have you created a test case in `_test/gatekeeper-integrationtests.sh`
- [x] Have you followed the TESTING.md doc? If not, please provide commands/steps to test this PR.
- [x] Have you re-generated `POLICIES.md`

cc: @redhat-cop/rego-policies
