### PR TITLE
moved comments block to top of file due to konstraint change

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -1623,6 +1623,8 @@ _source: [policy/ocp/requiresinventory/service-has-matching-servicemonitor](poli
 Most images are built from a subset of authorised base images in a company,
 this policy allows enforcement of that policy by checking for an expected SHA.
 
+parameter expected_layer_ids array string
+
 ### Rego
 
 ```rego
@@ -1653,6 +1655,8 @@ _source: [policy/podman/history/contains-layer](policy/podman/history/contains-l
 **Resources:** redhat-cop.github.com/PodmanImages
 
 Typically, the "smaller the better" rule applies to images so lets enforce that.
+
+parameter image_size_upperbound integer
 
 ### Rego
 

--- a/policy/combine/namespace-has-networkpolicy/src.rego
+++ b/policy/combine/namespace-has-networkpolicy/src.rego
@@ -1,7 +1,3 @@
-package combine.namespace_has_networkpolicy
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-COMBINE-00001: Namespace has a NetworkPolicy
 #
 # Kubernetes network policies specify the access permissions for groups of pods,
@@ -10,6 +6,10 @@ import data.lib.konstraint.core as konstraint_core
 # See: Network policies -> https://learnk8s.io/production-best-practices#governance
 #
 # @kinds core/Namespace networking.k8s.io/NetworkPolicy
+package combine.namespace_has_networkpolicy
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   manifests := input[_]
   some i

--- a/policy/combine/namespace-has-resourcequota/src.rego
+++ b/policy/combine/namespace-has-resourcequota/src.rego
@@ -1,16 +1,16 @@
-package combine.namespace_has_resourcequota
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-COMBINE-00002: Namespace has a ResourceQuota
 #
 # With ResourceQuotas, you can limit the total resource consumption of all containers inside a Namespace.
 # Defining a resource quota for a namespace limits the total amount of CPU, memory or storage resources
-# that can be consumed by all containers belonging to that namespace. You can also set quotas for other 
+# that can be consumed by all containers belonging to that namespace. You can also set quotas for other
 # Kubernetes objects such as the number of Pods in the current namespace.
 # See: Namespace limits -> https://learnk8s.io/production-best-practices#governance
 #
 # @kinds core/Namespace core/ResourceQuota
+package combine.namespace_has_resourcequota
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   manifests := input[_]
   some i

--- a/policy/ocp/bestpractices/common-k8s-labels-notset/src.rego
+++ b/policy/ocp/bestpractices/common-k8s-labels-notset/src.rego
@@ -1,14 +1,14 @@
-package ocp.bestpractices.common_k8s_labels_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00001: Common k8s labels are set
 #
 # Check if all workload related kinds contain labels as suggested by k8s.
 # See: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob core/Service route.openshift.io/Route
+package ocp.bestpractices.common_k8s_labels_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   openshift.is_policy_active("RHCOP-OCP_BESTPRACT-00001")
   openshift.is_pod_or_networking

--- a/policy/ocp/bestpractices/container-env-maxmemory-notset/src.rego
+++ b/policy/ocp/bestpractices/container-env-maxmemory-notset/src.rego
@@ -1,8 +1,3 @@
-package ocp.bestpractices.container_env_maxmemory_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00002: Container env has CONTAINER_MAX_MEMORY set
 #
 # Red Hat OpenJDK image uses CONTAINER_MAX_MEMORY env via the downward API to set Java memory settings.
@@ -10,6 +5,11 @@ import data.lib.openshift
 # See: https://github.com/jboss-openshift/cct_module/blob/master/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_env_maxmemory_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-image-latest/src.rego
+++ b/policy/ocp/bestpractices/container-image-latest/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.container_image_latest
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00003: Container image is not set as latest
 #
 # Images should use immutable tags. Today's latest is not tomorrows latest.
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_image_latest
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-image-unknownregistries/src.rego
+++ b/policy/ocp/bestpractices/container-image-unknownregistries/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.container_image_unknownregistries
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00004: Container image is not from a known registry
 #
 # Only images from trusted and known registries should be used
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_image_unknownregistries
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-java-xmx-set/src.rego
+++ b/policy/ocp/bestpractices/container-java-xmx-set/src.rego
@@ -1,14 +1,14 @@
-package ocp.bestpractices.container_java_xmx_set
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00005: Container does not set Java Xmx option
 #
 # Red Hat OpenJDK image uses CONTAINER_MAX_MEMORY env via the downward API to set Java memory settings.
 # Instead of manually setting -Xmx, let the image automatically set it for you.
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_java_xmx_set
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-labelkey-inconsistent/src.rego
+++ b/policy/ocp/bestpractices/container-labelkey-inconsistent/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.container_labelkey_inconsistent
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00006: Label key is consistent
 #
 # Label keys should be qualified by 'app.kubernetes.io' or 'company.com' to allow a consistent understanding.
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_labelkey_inconsistent
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   openshift.pod
 

--- a/policy/ocp/bestpractices/container-liveness-readinessprobe-equal/src.rego
+++ b/policy/ocp/bestpractices/container-liveness-readinessprobe-equal/src.rego
@@ -1,8 +1,3 @@
-package ocp.bestpractices.container_liveness_readinessprobe_equal
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00007: Container liveness and readiness probes are equal
 #
 # When Liveness and Readiness probes are pointing to the same endpoint, the effects of the probes are combined.
@@ -11,6 +6,11 @@ import data.lib.openshift
 # See: Health checks -> https://learnk8s.io/production-best-practices#application-development
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_liveness_readinessprobe_equal
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-livenessprobe-notset/src.rego
+++ b/policy/ocp/bestpractices/container-livenessprobe-notset/src.rego
@@ -1,8 +1,3 @@
-package ocp.bestpractices.container_livenessprobe_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00008: Container liveness prob is not set
 #
 # A Liveness checks determines if the container in which it is scheduled is still running.
@@ -10,6 +5,11 @@ import data.lib.openshift
 # See: https://docs.openshift.com/container-platform/4.6/applications/application-health.html
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_livenessprobe_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-readinessprobe-notset/src.rego
+++ b/policy/ocp/bestpractices/container-readinessprobe-notset/src.rego
@@ -1,8 +1,3 @@
-package ocp.bestpractices.container_readinessprobe_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00009: Container readiness prob is not set
 #
 # A Readiness check determines if the container in which it is scheduled is ready to service requests.
@@ -10,6 +5,11 @@ import data.lib.openshift
 # See: https://docs.openshift.com/container-platform/4.6/applications/application-health.html
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_readinessprobe_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-resources-limits-cpu-set/src.rego
+++ b/policy/ocp/bestpractices/container-resources-limits-cpu-set/src.rego
@@ -1,8 +1,3 @@
-package ocp.bestpractices.container_resources_limits_cpu_set
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00010: Container resource limits CPU not set
 #
 # If you're not sure about what's the best settings for your app, it's better not to set the CPU limits.
@@ -10,6 +5,11 @@ import data.lib.openshift
 # See: https://www.reddit.com/r/kubernetes/comments/all1vg/on_kubernetes_cpu_limits
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_resources_limits_cpu_set
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-resources-limits-memory-greater-than/src.rego
+++ b/policy/ocp/bestpractices/container-resources-limits-memory-greater-than/src.rego
@@ -1,9 +1,3 @@
-package ocp.bestpractices.container_resources_limits_memory_greater_than
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.memory
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00011: Container resource limits memory not greater than
 #
 # Setting a too high memory limit can cause under utilisation on a node.
@@ -11,6 +5,12 @@ import data.lib.openshift
 # See: Resources utilisation -> https://learnk8s.io/production-best-practices#application-development
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_resources_limits_memory_greater_than
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.memory
+import data.lib.openshift
+
 violation[msg] {
   #NOTE: upperBound is an arbitrary number and it should be changed to what your company believes is the correct policy
   upperBound := 6 * memory.gb

--- a/policy/ocp/bestpractices/container-resources-limits-memory-notset/src.rego
+++ b/policy/ocp/bestpractices/container-resources-limits-memory-notset/src.rego
@@ -1,8 +1,3 @@
-package ocp.bestpractices.container_resources_limits_memory_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00012: Container resource limits memory not set
 #
 # A container without a memory limit has memory utilisation of zero — according to the scheduler.
@@ -10,6 +5,11 @@ import data.lib.openshift
 # See: Resources utilisation -> https://learnk8s.io/production-best-practices#application-development
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_resources_limits_memory_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-resources-memoryunit-incorrect/src.rego
+++ b/policy/ocp/bestpractices/container-resources-memoryunit-incorrect/src.rego
@@ -1,8 +1,3 @@
-package ocp.bestpractices.container_resources_memoryunit_incorrect
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00013: Container resources limit memory has incorrect unit
 #
 # Begininers can easily confuse the allowed memory unit, this policy enforces what is valid.
@@ -11,6 +6,11 @@ import data.lib.openshift
 # See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_resources_memoryunit_incorrect
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-resources-requests-cpuunit-incorrect/src.rego
+++ b/policy/ocp/bestpractices/container-resources-requests-cpuunit-incorrect/src.rego
@@ -1,14 +1,14 @@
-package ocp.bestpractices.container_resources_requests_cpuunit_incorrect
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00014: Container resources requests cpu has incorrect unit
 #
 # Beginners can easily confuse the allowed cpu unit, this policy enforces what is valid.
 # See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_resources_requests_cpuunit_incorrect
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-resources-requests-memory-greater-than/src.rego
+++ b/policy/ocp/bestpractices/container-resources-requests-memory-greater-than/src.rego
@@ -1,9 +1,3 @@
-package ocp.bestpractices.container_resources_requests_memory_greater_than
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.memory
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00015: Container resource requests memory not greater than
 #
 # Setting a too high memory request can cause under utilisation on a node.
@@ -11,6 +5,12 @@ import data.lib.openshift
 # See: Resources utilisation -> https://learnk8s.io/production-best-practices#application-development
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_resources_requests_memory_greater_than
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.memory
+import data.lib.openshift
+
 violation[msg] {
   #NOTE: upperBound is an arbitrary number and it should be changed to what your company believes is the correct policy
   upperBound := 2 * memory.gb

--- a/policy/ocp/bestpractices/container-secret-mounted-envs/src.rego
+++ b/policy/ocp/bestpractices/container-secret-mounted-envs/src.rego
@@ -1,8 +1,3 @@
-package ocp.bestpractices.container_secret_mounted_envs
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00016: Container secret not mounted as envs
 #
 # The content of Secret resources should be mounted into containers as volumes rather than passed in as environment variables.
@@ -11,6 +6,11 @@ import data.lib.openshift
 # See: Configuration and secrets -> https://learnk8s.io/production-best-practices#application-development
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_secret_mounted_envs
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-volumemount-inconsistent-path/src.rego
+++ b/policy/ocp/bestpractices/container-volumemount-inconsistent-path/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.container_volumemount_inconsistent_path
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00017: Container volume mount path is consistent
 #
 # Mount paths should be mounted at '/var/run/company.com' to allow a consistent understanding.
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_volumemount_inconsistent_path
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   container := openshift.containers[_]
 

--- a/policy/ocp/bestpractices/container-volumemount-missing/src.rego
+++ b/policy/ocp/bestpractices/container-volumemount-missing/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.container_volumemount_missing
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00018: Container volume mount not set
 #
 # A volume does not have a corresponding volume mount. There is probably a mistake in your definition.
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.container_volumemount_missing
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   volume := openshift.pod.spec.volumes[_]
 

--- a/policy/ocp/bestpractices/deploymentconfig-triggers-notset/src.rego
+++ b/policy/ocp/bestpractices/deploymentconfig-triggers-notset/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.deploymentconfig_triggers_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00019: DeploymentConfig triggers not set
 #
 # If you are using a DeploymentConfig without 'spec.triggers' set, you could probably just use the k8s Deployment.
 #
 # @kinds apps.openshift.io/DeploymentConfig
+package ocp.bestpractices.deploymentconfig_triggers_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   openshift.is_deploymentconfig
 

--- a/policy/ocp/bestpractices/pod-antiaffinity-notset/src.rego
+++ b/policy/ocp/bestpractices/pod-antiaffinity-notset/src.rego
@@ -1,8 +1,3 @@
-package ocp.bestpractices.pod_antiaffinity_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00026: Pod anti-affinity not set
 #
 # Even if you run several copies of your Pods, there are no guarantees that losing a node won't take down your service.
@@ -11,6 +6,11 @@ import data.lib.openshift
 # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/Deployment apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod
+package ocp.bestpractices.pod_antiaffinity_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   openshift.pod
 

--- a/policy/ocp/bestpractices/pod-hostnetwork/src.rego
+++ b/policy/ocp/bestpractices/pod-hostnetwork/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.pod_hostnetwork
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00020: Pod hostnetwork not set
 #
 # Pods which require 'spec.hostNetwork' should be limited due to security concerns.
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/DaemonSet apps/Deployment apps/Job apps/ReplicaSet core/ReplicationController apps/StatefulSet core/Pod batch/CronJob
+package ocp.bestpractices.pod_hostnetwork
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   openshift.pod.spec.hostNetwork
 

--- a/policy/ocp/bestpractices/pod-replicas-below-one/src.rego
+++ b/policy/ocp/bestpractices/pod-replicas-below-one/src.rego
@@ -1,14 +1,14 @@
-package ocp.bestpractices.pod_replicas_below_one
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00021: Pod replica below 1
 #
 # Never run a single Pod individually.
 # See: Fault tolerance -> https://learnk8s.io/production-best-practices#application-development
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/Deployment
+package ocp.bestpractices.pod_replicas_below_one
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   openshift.pod
 

--- a/policy/ocp/bestpractices/pod-replicas-not-odd/src.rego
+++ b/policy/ocp/bestpractices/pod-replicas-not-odd/src.rego
@@ -1,14 +1,14 @@
-package ocp.bestpractices.pod_replicas_not_odd
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00022: Pod replica is not odd
 #
 # Pods should be run with a replica which is odd, i.e.: 3, 5, 7, etc, for HA guarantees.
 # See: Fault tolerance -> https://learnk8s.io/production-best-practices#application-development
 #
 # @kinds apps.openshift.io/DeploymentConfig apps/Deployment
+package ocp.bestpractices.pod_replicas_not_odd
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   openshift.pod
 

--- a/policy/ocp/bestpractices/rolebinding-roleref-apigroup-notset/src.rego
+++ b/policy/ocp/bestpractices/rolebinding-roleref-apigroup-notset/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.rolebinding_roleref_apigroup_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.kubernetes
-
 # @title RHCOP-OCP_BESTPRACT-00023: RoleBinding has apiGroup set
 #
 # Migrating from 3.11 to 4.x requires the 'roleRef.apiGroup' to be set.
 #
 # @kinds rbac.authorization.k8s.io/RoleBinding
+package ocp.bestpractices.rolebinding_roleref_apigroup_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.kubernetes
+
 violation[msg] {
   kubernetes.is_rolebinding
 

--- a/policy/ocp/bestpractices/rolebinding-roleref-kind-notset/src.rego
+++ b/policy/ocp/bestpractices/rolebinding-roleref-kind-notset/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.rolebinding_roleref_kind_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.kubernetes
-
 # @title RHCOP-OCP_BESTPRACT-00024: RoleBinding has kind set
 #
 # Migrating from 3.11 to 4.x requires the 'roleRef.kind' to be set.
 #
 # @kinds rbac.authorization.k8s.io/RoleBinding
+package ocp.bestpractices.rolebinding_roleref_kind_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.kubernetes
+
 violation[msg] {
   kubernetes.is_rolebinding
 

--- a/policy/ocp/bestpractices/route-tls-termination-notset/src.rego
+++ b/policy/ocp/bestpractices/route-tls-termination-notset/src.rego
@@ -1,13 +1,13 @@
-package ocp.bestpractices.route_tls_termination_notset
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.openshift
-
 # @title RHCOP-OCP_BESTPRACT-00025: Route has TLS Termination Defined
 #
 # Routes should specify a TLS termination type to allow only secure ingress.
 #
 # @kinds route.openshift.io/Route
+package ocp.bestpractices.route_tls_termination_notset
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.openshift
+
 violation[msg] {
   openshift.is_route
 

--- a/policy/ocp/deprecated/3_11/buildconfig-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/buildconfig-v1/src.rego
@@ -1,12 +1,12 @@
-package ocp.deprecated.ocp3_11.buildconfig_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-3.11-00001: BuildConfig no longer served by v1
 #
 # OCP4.x expects build.openshift.io/v1.
 #
 # @kinds v1/BuildConfig
+package ocp.deprecated.ocp3_11.buildconfig_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "v1"
   lower(konstraint_core.kind) == "buildconfig"

--- a/policy/ocp/deprecated/3_11/deploymentconfig-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/deploymentconfig-v1/src.rego
@@ -1,12 +1,12 @@
-package ocp.deprecated.ocp3_11.deploymentconfig_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-3.11-00002: DeploymentConfig no longer served by v1
 #
 # OCP4.x expects apps.openshift.io/v1.
 #
 # @kinds v1/DeploymentConfig
+package ocp.deprecated.ocp3_11.deploymentconfig_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "v1"
   lower(konstraint_core.kind) == "deploymentconfig"

--- a/policy/ocp/deprecated/3_11/imagestream-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/imagestream-v1/src.rego
@@ -1,12 +1,12 @@
-package ocp.deprecated.ocp3_11.imagestream_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-3.11-00003: ImageStream no longer served by v1
 #
 # OCP4.x expects image.openshift.io/v1.
 #
 # @kinds v1/ImageStream
+package ocp.deprecated.ocp3_11.imagestream_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "v1"
   lower(konstraint_core.kind) == "imagestream"

--- a/policy/ocp/deprecated/3_11/projectrequest-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/projectrequest-v1/src.rego
@@ -1,12 +1,12 @@
-package ocp.deprecated.ocp3_11.projectrequest_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-3.11-00004: ProjectRequest no longer served by v1
 #
 # OCP4.x expects project.openshift.io/v1.
 #
 # @kinds v1/ProjectRequest
+package ocp.deprecated.ocp3_11.projectrequest_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "v1"
   lower(konstraint_core.kind) == "projectrequest"

--- a/policy/ocp/deprecated/3_11/rolebinding-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/rolebinding-v1/src.rego
@@ -1,12 +1,12 @@
-package ocp.deprecated.ocp3_11.rolebinding_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-3.11-00005: RoleBinding no longer served by v1
 #
 # OCP4.x expects rbac.authorization.k8s.io/v1
 #
 # @kinds v1/RoleBinding
+package ocp.deprecated.ocp3_11.rolebinding_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "v1"
   lower(konstraint_core.kind) == "rolebinding"

--- a/policy/ocp/deprecated/3_11/route-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/route-v1/src.rego
@@ -1,12 +1,12 @@
-package ocp.deprecated.ocp3_11.route_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-3.11-00006: Route no longer served by v1
 #
 # OCP4.x expects route.openshift.io/v1.
 #
 # @kinds v1/Route
+package ocp.deprecated.ocp3_11.route_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "v1"
   lower(konstraint_core.kind) == "route"

--- a/policy/ocp/deprecated/3_11/securitycontextconstraints-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/securitycontextconstraints-v1/src.rego
@@ -1,12 +1,12 @@
-package ocp.deprecated.ocp3_11.securitycontextconstraints_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-3.11-00007: SecurityContextConstraints no longer served by v1
 #
 # OCP4.x expects security.openshift.io/v1.
 #
 # @kinds v1/SecurityContextConstraints
+package ocp.deprecated.ocp3_11.securitycontextconstraints_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "v1"
   lower(konstraint_core.kind) == "securitycontextconstraints"

--- a/policy/ocp/deprecated/3_11/template-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/template-v1/src.rego
@@ -1,12 +1,12 @@
-package ocp.deprecated.ocp3_11.template_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-3.11-00008: Template no longer served by v1
 #
 # OCP4.x expects template.openshift.io/v1.
 #
 # @kinds v1/Template
+package ocp.deprecated.ocp3_11.template_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "v1"
   lower(konstraint_core.kind) == "template"

--- a/policy/ocp/deprecated/4_1/buildconfig-custom-strategy/src.rego
+++ b/policy/ocp/deprecated/4_1/buildconfig-custom-strategy/src.rego
@@ -1,13 +1,13 @@
-package ocp.deprecated.ocp4_1.buildconfig_custom_strategy
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-4.1-00001: BuildConfig exposeDockerSocket deprecated
 #
 # 'spec.strategy.customStrategy.exposeDockerSocket' is no longer supported by BuildConfig.
 # See: https://docs.openshift.com/container-platform/4.1/release_notes/ocp-4-1-release-notes.html#ocp-41-deprecated-features
 #
 # @kinds build.openshift.io/BuildConfig
+package ocp.deprecated.ocp4_1.buildconfig_custom_strategy
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "build.openshift.io/v1"
   lower(konstraint_core.kind) == "buildconfig"

--- a/policy/ocp/deprecated/4_2/authorization-openshift/src.rego
+++ b/policy/ocp/deprecated/4_2/authorization-openshift/src.rego
@@ -1,13 +1,13 @@
-package ocp.deprecated.ocp4_2.authorization_openshift
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-4.2-00001: authorization openshift io is deprecated
 #
 # From OCP4.2 onwards, you should migrate from 'authorization.openshift.io' to rbac.authorization.k8s.io/v1.
 # See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
 #
 # @kinds authorization.openshift.io/ClusterRole authorization.openshift.io/ClusterRoleBinding authorization.openshift.io/Role authorization.openshift.io/RoleBinding
+package ocp.deprecated.ocp4_2.authorization_openshift
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   contains(lower(konstraint_core.apiVersion), "authorization.openshift.io")
 

--- a/policy/ocp/deprecated/4_2/automationbroker-v1alpha1/src.rego
+++ b/policy/ocp/deprecated/4_2/automationbroker-v1alpha1/src.rego
@@ -1,7 +1,3 @@
-package ocp.deprecated.ocp4_2.automationbroker_v1alpha1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-4.2-00002: automationbroker io v1alpha1 is deprecated
 #
 # 'automationbroker.io/v1alpha1' is deprecated in OCP 4.2 and removed in 4.4.
@@ -9,6 +5,10 @@ import data.lib.konstraint.core as konstraint_core
 # See: https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-deprecated-removed-features
 #
 # @kinds automationbroker.io/Bundle automationbroker.io/BundleBinding automationbroker.io/BundleInstance
+package ocp.deprecated.ocp4_2.automationbroker_v1alpha1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   contains(lower(konstraint_core.apiVersion), "automationbroker.io/v1alpha1")
 

--- a/policy/ocp/deprecated/4_2/catalogsourceconfigs-v1/src.rego
+++ b/policy/ocp/deprecated/4_2/catalogsourceconfigs-v1/src.rego
@@ -1,7 +1,3 @@
-package ocp.deprecated.ocp4_2.catalogsourceconfigs_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-4.2-00003: operators coreos com v1 CatalogSourceConfigs is deprecated
 #
 # 'operators.coreos.com/v1:CatalogSourceConfigs' is deprecated in OCP 4.2 and removed in 4.5.
@@ -9,6 +5,10 @@ import data.lib.konstraint.core as konstraint_core
 # See: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-deprecated-removed-features
 #
 # @kinds operators.coreos.com/CatalogSourceConfigs
+package ocp.deprecated.ocp4_2.catalogsourceconfigs_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   contains(lower(konstraint_core.apiVersion), "operators.coreos.com/v1")
   lower(konstraint_core.kind) == "catalogsourceconfigs"

--- a/policy/ocp/deprecated/4_2/catalogsourceconfigs-v2/src.rego
+++ b/policy/ocp/deprecated/4_2/catalogsourceconfigs-v2/src.rego
@@ -1,7 +1,3 @@
-package ocp.deprecated.ocp4_2.catalogsourceconfigs_v2
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-4.2-00004: operators coreos com v2 CatalogSourceConfigs is deprecated
 #
 # 'operators.coreos.com/v2:CatalogSourceConfigs' is deprecated in OCP 4.2 and removed in 4.5.
@@ -9,6 +5,10 @@ import data.lib.konstraint.core as konstraint_core
 # See: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-deprecated-removed-features
 #
 # @kinds operators.coreos.com/CatalogSourceConfigs
+package ocp.deprecated.ocp4_2.catalogsourceconfigs_v2
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   contains(lower(konstraint_core.apiVersion), "operators.coreos.com/v2")
   lower(konstraint_core.kind) == "catalogsourceconfigs"

--- a/policy/ocp/deprecated/4_2/operatorsources-v1/src.rego
+++ b/policy/ocp/deprecated/4_2/operatorsources-v1/src.rego
@@ -1,13 +1,13 @@
-package ocp.deprecated.ocp4_2.operatorsources_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-4.2-00005: operators coreos com v1 OperatorSource is deprecated
 #
 # 'operators.coreos.com/v1:OperatorSource' is deprecated in OCP 4.2 and will be removed in a future version.
 # See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
 #
 # @kinds operators.coreos.com/OperatorSource
+package ocp.deprecated.ocp4_2.operatorsources_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   contains(lower(konstraint_core.apiVersion), "operators.coreos.com/v1")
   lower(konstraint_core.kind) == "operatorsource"

--- a/policy/ocp/deprecated/4_2/osb-v1/src.rego
+++ b/policy/ocp/deprecated/4_2/osb-v1/src.rego
@@ -1,7 +1,3 @@
-package ocp.deprecated.ocp4_2.osb_v1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-4.2-00006: osb openshift io v1 is deprecated
 #
 # 'osb.openshift.io/v1' is deprecated in OCP 4.2 and removed in 4.5.
@@ -9,6 +5,10 @@ import data.lib.konstraint.core as konstraint_core
 # See: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-deprecated-removed-features
 #
 # @kinds osb.openshift.io/TemplateServiceBroker osb.openshift.io/AutomationBroker
+package ocp.deprecated.ocp4_2.osb_v1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   contains(lower(konstraint_core.apiVersion), "osb.openshift.io/v1")
 

--- a/policy/ocp/deprecated/4_2/servicecatalog-v1beta1/src.rego
+++ b/policy/ocp/deprecated/4_2/servicecatalog-v1beta1/src.rego
@@ -1,7 +1,3 @@
-package ocp.deprecated.ocp4_2.servicecatalog_v1beta1
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-4.2-00007: servicecatalog k8s io v1beta1 is deprecated
 #
 # 'servicecatalog.k8s.io/v1beta1' is deprecated in OCP 4.2 and removed in 4.5.
@@ -9,6 +5,10 @@ import data.lib.konstraint.core as konstraint_core
 # See: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-deprecated-removed-features
 #
 # @kinds servicecatalog.k8s.io/ClusterServiceBroker servicecatalog.k8s.io/ClusterServiceClass servicecatalog.k8s.io/ClusterServicePlan servicecatalog.k8s.io/ServiceInstance servicecatalog.k8s.io/ServiceBinding
+package ocp.deprecated.ocp4_2.servicecatalog_v1beta1
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   contains(lower(konstraint_core.apiVersion), "servicecatalog.k8s.io/v1beta1")
 

--- a/policy/ocp/deprecated/4_3/buildconfig-jenkinspipeline-strategy/src.rego
+++ b/policy/ocp/deprecated/4_3/buildconfig-jenkinspipeline-strategy/src.rego
@@ -1,13 +1,13 @@
-package ocp.deprecated.ocp4_3.buildconfig_jenkinspipeline_strategy
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-OCP_DEPRECATED-4.3-00001: BuildConfig jenkinsPipelineStrategy is deprecated
 #
 # 'spec.strategy.jenkinsPipelineStrategy' is no longer supported by BuildConfig.
 # See: https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html#ocp-4-3-deprecated-features
 #
 # @kinds build.openshift.io/BuildConfig
+package ocp.deprecated.ocp4_3.buildconfig_jenkinspipeline_strategy
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(konstraint_core.apiVersion) == "build.openshift.io/v1"
   lower(konstraint_core.kind) == "buildconfig"

--- a/policy/ocp/requiresinventory/deployment-has-matching-poddisruptionbudget/src.rego
+++ b/policy/ocp/requiresinventory/deployment-has-matching-poddisruptionbudget/src.rego
@@ -1,8 +1,3 @@
-package ocp.requiresinventory.deployment_has_matching_poddisruptionbudget
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.kubernetes
-
 # @title RHCOP-OCP_REQ_INV-00001: Deployment has a matching PodDisruptionBudget
 #
 # All Deployments should have matching PodDisruptionBudget, via 'spec.template.metadata.labels', to provide HA guarantees.
@@ -10,6 +5,11 @@ import data.lib.kubernetes
 # See: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 #
 # @kinds apps/Deployment
+package ocp.requiresinventory.deployment_has_matching_poddisruptionbudget
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.kubernetes
+
 violation[msg] {
   kubernetes.is_deployment
 

--- a/policy/ocp/requiresinventory/deployment-has-matching-pvc/src.rego
+++ b/policy/ocp/requiresinventory/deployment-has-matching-pvc/src.rego
@@ -1,14 +1,14 @@
-package ocp.requiresinventory.deployment_has_matching_pvc
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.kubernetes
-
 # @title RHCOP-OCP_REQ_INV-00002: Deployment has matching PersistentVolumeClaim
 #
 # If Deployment has 'spec.template.spec.volumes.persistentVolumeClaim' set, there should be matching PersistentVolumeClaim.
 # If not, this would suggest a mistake.
 #
 # @kinds apps/Deployment
+package ocp.requiresinventory.deployment_has_matching_pvc
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.kubernetes
+
 violation[msg] {
   kubernetes.is_deployment
 

--- a/policy/ocp/requiresinventory/deployment-has-matching-service/src.rego
+++ b/policy/ocp/requiresinventory/deployment-has-matching-service/src.rego
@@ -1,14 +1,14 @@
-package ocp.requiresinventory.deployment_has_matching_service
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.kubernetes
-
 # @title RHCOP-OCP_REQ_INV-00003: Deployment has a matching Service
 #
 # All Deployments should have matching Service, via 'spec.template.metadata.labels'.
 # Deployments without a Service are not accessible and should be questioned as to why.
 #
 # @kinds apps/Deployment
+package ocp.requiresinventory.deployment_has_matching_service
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.kubernetes
+
 violation[msg] {
   kubernetes.is_deployment
 

--- a/policy/ocp/requiresinventory/deployment-has-matching-serviceaccount/src.rego
+++ b/policy/ocp/requiresinventory/deployment-has-matching-serviceaccount/src.rego
@@ -1,14 +1,14 @@
-package ocp.requiresinventory.deployment_has_matching_serviceaccount
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.kubernetes
-
 # @title RHCOP-OCP_REQ_INV-00004: Deployment has matching ServiceAccount
 #
 # If Deployment has 'spec.serviceAccountName' set, there should be matching ServiceAccount.
 # If not, this would suggest a mistake.
 #
 # @kinds apps/Deployment
+package ocp.requiresinventory.deployment_has_matching_serviceaccount
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.kubernetes
+
 violation[msg] {
   kubernetes.is_deployment
 

--- a/policy/ocp/requiresinventory/service-has-matching-servicemonitor/src.rego
+++ b/policy/ocp/requiresinventory/service-has-matching-servicemonitor/src.rego
@@ -1,14 +1,14 @@
-package ocp.requiresinventory.service_has_matching_servicenonitor
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.kubernetes
-
 # @title RHCOP-OCP_REQ_INV-00005: Service has matching ServiceMonitor
 #
 # All Service should have a matching ServiceMonitor, via 'spec.selector'.
 # Service without a ServiceMonitor are not being monitored and should be questioned as to why.
 #
 # @kinds core/Service
+package ocp.requiresinventory.service_has_matching_servicenonitor
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.kubernetes
+
 violation[msg] {
   kubernetes.is_service
 

--- a/policy/podman/history/contains-layer/src.rego
+++ b/policy/podman/history/contains-layer/src.rego
@@ -1,7 +1,3 @@
-package podman.history.contains_layer
-
-import data.lib.konstraint.core as konstraint_core
-
 # @title RHCOP-PODMAN-00001: Image contains expected SHA in history.
 #
 # Most images are built from a subset of authorised base images in a company,
@@ -9,6 +5,10 @@ import data.lib.konstraint.core as konstraint_core
 #
 # @kinds redhat-cop.github.com/PodmanHistory
 # parameter expected_layer_ids array string
+package podman.history.contains_layer
+
+import data.lib.konstraint.core as konstraint_core
+
 violation[msg] {
   lower(input.apiVersion) == "redhat-cop.github.com/v1"
   lower(input.kind) == "podmanhistory"

--- a/policy/podman/images/image-size-not-greater-than/src.rego
+++ b/policy/podman/images/image-size-not-greater-than/src.rego
@@ -1,14 +1,14 @@
-package podman.images.image_size_not_greater_than
-
-import data.lib.konstraint.core as konstraint_core
-import data.lib.memory
-
 # @title RHCOP-PODMAN-00002: Image size is not greater than an expected value
 #
 # Typically, the "smaller the better" rule applies to images so lets enforce that.
 #
 # @kinds redhat-cop.github.com/PodmanImages
 # parameter image_size_upperbound integer
+package podman.images.image_size_not_greater_than
+
+import data.lib.konstraint.core as konstraint_core
+import data.lib.memory
+
 violation[msg] {
   lower(input.apiVersion) == "redhat-cop.github.com/v1"
   lower(input.kind) == "podmanimages"


### PR DESCRIPTION
#### What is this PR About?
konstraint changed how comments are parsed, which means they now need to be at the top of the file:
- https://github.com/plexsystems/konstraint/pull/104

no policy logic changed, just moved comment blocks above package.

#### Check list
- [x] Have you created a test case in `_test/conftest-unittests.sh`
- [x] Have you created a test case in `_test/opa-profile.sh`
- [x] Have you re-generated `POLICIES.md`

cc: @redhat-cop/rego-policies
