### PR TITLE
added @skip-constraint to policies which cannot be deployed against gatekeeper

### DIFF
--- a/_test/deploy-gatekeeper.sh
+++ b/_test/deploy-gatekeeper.sh
@@ -90,7 +90,7 @@ generate_constraints() {
   konstraint create
 
   # shellcheck disable=SC2038
-  for file in $(find policy/* \( -name "template.yaml" -o -name "constraint.yaml" \) -type f | xargs); do
+  for file in $(find policy/* \( -name "template.yaml" \) -type f | xargs); do
     if [[ "${file}" == *"/combine/"* ]]; then
       # the data is 'off-cluster' so cant be tested against gatekeeper
       rm -f "${file}"

--- a/policy/combine/namespace-has-networkpolicy/src.rego
+++ b/policy/combine/namespace-has-networkpolicy/src.rego
@@ -5,6 +5,7 @@
 # In other words, it creates firewalls between pods running on a Kubernetes cluster.
 # See: Network policies -> https://learnk8s.io/production-best-practices#governance
 #
+# @skip-constraint
 # @kinds core/Namespace networking.k8s.io/NetworkPolicy
 package combine.namespace_has_networkpolicy
 

--- a/policy/combine/namespace-has-resourcequota/src.rego
+++ b/policy/combine/namespace-has-resourcequota/src.rego
@@ -6,6 +6,7 @@
 # Kubernetes objects such as the number of Pods in the current namespace.
 # See: Namespace limits -> https://learnk8s.io/production-best-practices#governance
 #
+# @skip-constraint
 # @kinds core/Namespace core/ResourceQuota
 package combine.namespace_has_resourcequota
 

--- a/policy/ocp/bestpractices/deploymentconfig-triggers-notset/src.rego
+++ b/policy/ocp/bestpractices/deploymentconfig-triggers-notset/src.rego
@@ -2,6 +2,7 @@
 #
 # If you are using a DeploymentConfig without 'spec.triggers' set, you could probably just use the k8s Deployment.
 #
+# @skip-constraint
 # @kinds apps.openshift.io/DeploymentConfig
 package ocp.bestpractices.deploymentconfig_triggers_notset
 

--- a/policy/ocp/bestpractices/rolebinding-roleref-apigroup-notset/src.rego
+++ b/policy/ocp/bestpractices/rolebinding-roleref-apigroup-notset/src.rego
@@ -2,6 +2,7 @@
 #
 # Migrating from 3.11 to 4.x requires the 'roleRef.apiGroup' to be set.
 #
+# @skip-constraint
 # @kinds rbac.authorization.k8s.io/RoleBinding
 package ocp.bestpractices.rolebinding_roleref_apigroup_notset
 

--- a/policy/ocp/bestpractices/rolebinding-roleref-kind-notset/src.rego
+++ b/policy/ocp/bestpractices/rolebinding-roleref-kind-notset/src.rego
@@ -2,6 +2,7 @@
 #
 # Migrating from 3.11 to 4.x requires the 'roleRef.kind' to be set.
 #
+# @skip-constraint
 # @kinds rbac.authorization.k8s.io/RoleBinding
 package ocp.bestpractices.rolebinding_roleref_kind_notset
 

--- a/policy/ocp/deprecated/3_11/buildconfig-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/buildconfig-v1/src.rego
@@ -2,6 +2,7 @@
 #
 # OCP4.x expects build.openshift.io/v1.
 #
+# @skip-constraint
 # @kinds v1/BuildConfig
 package ocp.deprecated.ocp3_11.buildconfig_v1
 

--- a/policy/ocp/deprecated/3_11/deploymentconfig-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/deploymentconfig-v1/src.rego
@@ -2,6 +2,7 @@
 #
 # OCP4.x expects apps.openshift.io/v1.
 #
+# @skip-constraint
 # @kinds v1/DeploymentConfig
 package ocp.deprecated.ocp3_11.deploymentconfig_v1
 

--- a/policy/ocp/deprecated/3_11/imagestream-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/imagestream-v1/src.rego
@@ -2,6 +2,7 @@
 #
 # OCP4.x expects image.openshift.io/v1.
 #
+# @skip-constraint
 # @kinds v1/ImageStream
 package ocp.deprecated.ocp3_11.imagestream_v1
 

--- a/policy/ocp/deprecated/3_11/projectrequest-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/projectrequest-v1/src.rego
@@ -2,6 +2,7 @@
 #
 # OCP4.x expects project.openshift.io/v1.
 #
+# @skip-constraint
 # @kinds v1/ProjectRequest
 package ocp.deprecated.ocp3_11.projectrequest_v1
 

--- a/policy/ocp/deprecated/3_11/rolebinding-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/rolebinding-v1/src.rego
@@ -2,6 +2,7 @@
 #
 # OCP4.x expects rbac.authorization.k8s.io/v1
 #
+# @skip-constraint
 # @kinds v1/RoleBinding
 package ocp.deprecated.ocp3_11.rolebinding_v1
 

--- a/policy/ocp/deprecated/3_11/route-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/route-v1/src.rego
@@ -2,6 +2,7 @@
 #
 # OCP4.x expects route.openshift.io/v1.
 #
+# @skip-constraint
 # @kinds v1/Route
 package ocp.deprecated.ocp3_11.route_v1
 

--- a/policy/ocp/deprecated/3_11/securitycontextconstraints-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/securitycontextconstraints-v1/src.rego
@@ -2,6 +2,7 @@
 #
 # OCP4.x expects security.openshift.io/v1.
 #
+# @skip-constraint
 # @kinds v1/SecurityContextConstraints
 package ocp.deprecated.ocp3_11.securitycontextconstraints_v1
 

--- a/policy/ocp/deprecated/3_11/template-v1/src.rego
+++ b/policy/ocp/deprecated/3_11/template-v1/src.rego
@@ -2,6 +2,7 @@
 #
 # OCP4.x expects template.openshift.io/v1.
 #
+# @skip-constraint
 # @kinds v1/Template
 package ocp.deprecated.ocp3_11.template_v1
 

--- a/policy/ocp/deprecated/4_1/buildconfig-custom-strategy/src.rego
+++ b/policy/ocp/deprecated/4_1/buildconfig-custom-strategy/src.rego
@@ -3,6 +3,7 @@
 # 'spec.strategy.customStrategy.exposeDockerSocket' is no longer supported by BuildConfig.
 # See: https://docs.openshift.com/container-platform/4.1/release_notes/ocp-4-1-release-notes.html#ocp-41-deprecated-features
 #
+# @skip-constraint
 # @kinds build.openshift.io/BuildConfig
 package ocp.deprecated.ocp4_1.buildconfig_custom_strategy
 

--- a/policy/ocp/deprecated/4_2/authorization-openshift/src.rego
+++ b/policy/ocp/deprecated/4_2/authorization-openshift/src.rego
@@ -3,6 +3,7 @@
 # From OCP4.2 onwards, you should migrate from 'authorization.openshift.io' to rbac.authorization.k8s.io/v1.
 # See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
 #
+# @skip-constraint
 # @kinds authorization.openshift.io/ClusterRole authorization.openshift.io/ClusterRoleBinding authorization.openshift.io/Role authorization.openshift.io/RoleBinding
 package ocp.deprecated.ocp4_2.authorization_openshift
 

--- a/policy/ocp/deprecated/4_2/automationbroker-v1alpha1/src.rego
+++ b/policy/ocp/deprecated/4_2/automationbroker-v1alpha1/src.rego
@@ -4,6 +4,7 @@
 # See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
 # See: https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-deprecated-removed-features
 #
+# @skip-constraint
 # @kinds automationbroker.io/Bundle automationbroker.io/BundleBinding automationbroker.io/BundleInstance
 package ocp.deprecated.ocp4_2.automationbroker_v1alpha1
 

--- a/policy/ocp/deprecated/4_2/catalogsourceconfigs-v1/src.rego
+++ b/policy/ocp/deprecated/4_2/catalogsourceconfigs-v1/src.rego
@@ -4,6 +4,7 @@
 # See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
 # See: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-deprecated-removed-features
 #
+# @skip-constraint
 # @kinds operators.coreos.com/CatalogSourceConfigs
 package ocp.deprecated.ocp4_2.catalogsourceconfigs_v1
 

--- a/policy/ocp/deprecated/4_2/catalogsourceconfigs-v2/src.rego
+++ b/policy/ocp/deprecated/4_2/catalogsourceconfigs-v2/src.rego
@@ -4,6 +4,7 @@
 # See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
 # See: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-deprecated-removed-features
 #
+# @skip-constraint
 # @kinds operators.coreos.com/CatalogSourceConfigs
 package ocp.deprecated.ocp4_2.catalogsourceconfigs_v2
 

--- a/policy/ocp/deprecated/4_2/operatorsources-v1/src.rego
+++ b/policy/ocp/deprecated/4_2/operatorsources-v1/src.rego
@@ -3,6 +3,7 @@
 # 'operators.coreos.com/v1:OperatorSource' is deprecated in OCP 4.2 and will be removed in a future version.
 # See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
 #
+# @skip-constraint
 # @kinds operators.coreos.com/OperatorSource
 package ocp.deprecated.ocp4_2.operatorsources_v1
 

--- a/policy/ocp/deprecated/4_2/osb-v1/src.rego
+++ b/policy/ocp/deprecated/4_2/osb-v1/src.rego
@@ -4,6 +4,7 @@
 # See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
 # See: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-deprecated-removed-features
 #
+# @skip-constraint
 # @kinds osb.openshift.io/TemplateServiceBroker osb.openshift.io/AutomationBroker
 package ocp.deprecated.ocp4_2.osb_v1
 

--- a/policy/ocp/deprecated/4_2/servicecatalog-v1beta1/src.rego
+++ b/policy/ocp/deprecated/4_2/servicecatalog-v1beta1/src.rego
@@ -4,6 +4,7 @@
 # See: https://docs.openshift.com/container-platform/4.2/release_notes/ocp-4-2-release-notes.html#ocp-4-2-deprecated-features
 # See: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-deprecated-removed-features
 #
+# @skip-constraint
 # @kinds servicecatalog.k8s.io/ClusterServiceBroker servicecatalog.k8s.io/ClusterServiceClass servicecatalog.k8s.io/ClusterServicePlan servicecatalog.k8s.io/ServiceInstance servicecatalog.k8s.io/ServiceBinding
 package ocp.deprecated.ocp4_2.servicecatalog_v1beta1
 

--- a/policy/ocp/deprecated/4_3/buildconfig-jenkinspipeline-strategy/src.rego
+++ b/policy/ocp/deprecated/4_3/buildconfig-jenkinspipeline-strategy/src.rego
@@ -3,6 +3,7 @@
 # 'spec.strategy.jenkinsPipelineStrategy' is no longer supported by BuildConfig.
 # See: https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html#ocp-4-3-deprecated-features
 #
+# @skip-constraint
 # @kinds build.openshift.io/BuildConfig
 package ocp.deprecated.ocp4_3.buildconfig_jenkinspipeline_strategy
 

--- a/policy/podman/history/contains-layer/src.rego
+++ b/policy/podman/history/contains-layer/src.rego
@@ -3,6 +3,7 @@
 # Most images are built from a subset of authorised base images in a company,
 # this policy allows enforcement of that policy by checking for an expected SHA.
 #
+# @skip-constraint
 # @kinds redhat-cop.github.com/PodmanHistory
 # parameter expected_layer_ids array string
 package podman.history.contains_layer

--- a/policy/podman/images/image-size-not-greater-than/src.rego
+++ b/policy/podman/images/image-size-not-greater-than/src.rego
@@ -2,6 +2,7 @@
 #
 # Typically, the "smaller the better" rule applies to images so lets enforce that.
 #
+# @skip-constraint
 # @kinds redhat-cop.github.com/PodmanImages
 # parameter image_size_upperbound integer
 package podman.images.image_size_not_greater_than


### PR DESCRIPTION
#### What is this PR About?
konstraint supports an annotation to skip generating a constraint. have added this to the ones which are not gatekeeper compatible 

#### Check list
- [x] Have you created a test case in `_test/conftest-unittests.sh`
- [x] Have you created a test case in `_test/opa-profile.sh`
- [x] Have you created a test case in `_test/gatekeeper-integrationtests.sh`
- [x] Have you followed the TESTING.md doc? If not, please provide commands/steps to test this PR.
- [x] Have you re-generated `POLICIES.md`

cc: @redhat-cop/rego-policies
