### PR TITLE
Add cleanup option and ignore missing CRDs

### DIFF
--- a/_test/deploy-gatekeeper.sh
+++ b/_test/deploy-gatekeeper.sh
@@ -10,7 +10,7 @@ gatekeeper_version="v3.3.0"
 cleanup_gatekeeper_constraints() {
   echo ""
   echo "Deleting all ConstraintTemplates..."
-  oc delete constrainttemplate.templates.gatekeeper.sh --all --ignore-not-found=true
+  oc delete constrainttemplate.templates.gatekeeper.sh --all --ignore-not-found=true || true
 
   find policy/* \( -name "template.yaml" -o -name "constraint.yaml" \) -type f -exec rm -f {} \;
 }
@@ -18,7 +18,7 @@ cleanup_gatekeeper_constraints() {
 cleanup_gatekeeper() {
   echo ""
   echo "Cleaning up previous gatekeeper installation..."
-  oc delete config.config.gatekeeper.sh -n gatekeeper-system --all --ignore-not-found=true
+  oc delete config.config.gatekeeper.sh -n gatekeeper-system --all --ignore-not-found=true || true
   oc delete -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/${gatekeeper_version}/deploy/gatekeeper.yaml --ignore-not-found=true
   oc delete -f gatekeeper/gatekeeper-template-manager.yml --ignore-not-found=true
 
@@ -166,6 +166,10 @@ case $1 in
     restart_gatekeeper
     generate_constraints
     deploy_constraints
+    ;;
+  cleanup_gatekeeper)
+    cleanup_gatekeeper_constraints
+    cleanup_gatekeeper
     ;;
   *)
     echo "Not an option"


### PR DESCRIPTION
#### What is this PR About?
Added a `|| true` so that if Gatekeeper isn't already installed in the cluster, the test script won't fail first time. (it failed for me because the CRD was missing)
Also added a cleanup option to the script which runs the cleanup functions.

#### Check list
- [ ] Have you created a test case in `_test/conftest-unittests.sh`
- [ ] Have you created a test case in `_test/opa-profile.sh`
- [ ] Have you created a test case in `_test/gatekeeper-integrationtests.sh`
- [ ] Have you followed the TESTING.md doc? If not, please provide commands/steps to test this PR.
- [ ] Have you re-generated `POLICIES.md`

To test - re-run the scripts in TESTING.md

cc: @redhat-cop/rego-policies
