### PR TITLE
Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
#### What is this PR About?
This PR configures Dependabot to watch this repo for outdated GH Actions and allows it to open a PR for updated versions. The results of this can be seen here: https://github.com/tylerauerbeck/charts-3/pull/1

#### Check list
- [ ] Have you created a test case in `_test/conftest-unittests.sh`
- [ ] Have you created a test case in `_test/opa-profile.sh`
- [ ] Have you created a test case in `_test/gatekeeper-integrationtests.sh`
- [ ] Have you followed the TESTING.md doc? If not, please provide commands/steps to test this PR.
- [ ] Have you re-generated `POLICIES.md`

cc: @redhat-cop/rego-policies
