### PR TITLE
added kind support to deploy gatekeeper and crds

### DIFF
--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -19,3 +19,11 @@ jobs:
         with:
           tests: _test/conftest-unittests.sh
           policies: '[{"name": "deprek8ion", "url":"github.com/swade1987/deprek8ion.git//policies"}]'
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.1.0
+
+      - name: Test against KinD
+        run: |
+          confbatstest=$(docker images | head -n 2 | tail -1 | xargs | cut -d" " -f-2 | sed -e 's/ /:/g')
+          docker run --rm --network host --workdir /conftest -v "/home/runner/.kube/":"/root/.kube/" -v "/home/runner/work/rego-policies/rego-policies":"/conftest" ${confbatstest} "" "" "kubectl cluster-info && _test/prow.sh deploy"


### PR DESCRIPTION
#### What is this PR About?
first PR to add KinD support:
- https://github.com/redhat-cop/rego-policies/issues/155

needs another PR to run `gatekeeper-integrationtests.sh` but that currently includes OCP specific tests (i.e.: DeploymentConfig, Templates and Projects) so will do that as another PR

cc: @redhat-cop/rego-policies
