### PR TITLE
Updated gatekeeper to 3.7.0 (latest)

### DIFF
--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -32,6 +32,15 @@ jobs:
         if: ${{ failure() }}
         run: |
           kubectl get nodes
+
+          echo ""
           kubectl get namespaces
+
+          echo ""
           kubectl get pods --all-namespaces
+
+          echo ""
           kubectl get events --all-namespaces
+
+          echo ""
+          kubectl api-versions

--- a/_test/gatekeeper-integrationtests.sh
+++ b/_test/gatekeeper-integrationtests.sh
@@ -59,8 +59,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by commonk8slabelsnotset] RHCOP-OCP_BESTPRACT-00001: Deployment/nolabels"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by commonk8slabelsnotset] RHCOP-OCP_BESTPRACT-00001: DeploymentConfig/nolabels"* ]]
+  [[ "${lines[0]}" == "Error from server ([commonk8slabelsnotset] RHCOP-OCP_BESTPRACT-00001: Deployment/nolabels"* ]]
+  [[ "${lines[1]}" == "Error from server ([commonk8slabelsnotset] RHCOP-OCP_BESTPRACT-00001: DeploymentConfig/nolabels"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -72,8 +72,8 @@ teardown() {
   
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerenvmaxmemorynotset] RHCOP-OCP_BESTPRACT-00002: Deployment/nodownwardmemoryenv"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerenvmaxmemorynotset] RHCOP-OCP_BESTPRACT-00002: DeploymentConfig/nodownwardmemoryenv"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerenvmaxmemorynotset] RHCOP-OCP_BESTPRACT-00002: Deployment/nodownwardmemoryenv"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerenvmaxmemorynotset] RHCOP-OCP_BESTPRACT-00002: DeploymentConfig/nodownwardmemoryenv"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -85,8 +85,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerimagelatest] RHCOP-OCP_BESTPRACT-00003: Deployment/imageuseslatesttag"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerimagelatest] RHCOP-OCP_BESTPRACT-00003: DeploymentConfig/imageuseslatesttag"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerimagelatest] RHCOP-OCP_BESTPRACT-00003: Deployment/imageuseslatesttag"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerimagelatest] RHCOP-OCP_BESTPRACT-00003: DeploymentConfig/imageuseslatesttag"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -98,8 +98,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerimageunknownregistries] RHCOP-OCP_BESTPRACT-00004: Deployment/imagefromunknownregistry"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerimageunknownregistries] RHCOP-OCP_BESTPRACT-00004: DeploymentConfig/imagefromunknownregistry"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerimageunknownregistries] RHCOP-OCP_BESTPRACT-00004: Deployment/imagefromunknownregistry"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerimageunknownregistries] RHCOP-OCP_BESTPRACT-00004: DeploymentConfig/imagefromunknownregistry"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -111,12 +111,12 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviacommand"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviaargs"* ]]
-  [[ "${lines[2]}" == "Error from server ([denied by containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviaenv"* ]]
-  [[ "${lines[3]}" == "Error from server ([denied by containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: DeploymentConfig/xmxviacommand"* ]]
-  [[ "${lines[4]}" == "Error from server ([denied by containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: DeploymentConfig/xmxviaargs"* ]]
-  [[ "${lines[5]}" == "Error from server ([denied by containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: DeploymentConfig/xmxviaenv"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviacommand"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviaargs"* ]]
+  [[ "${lines[2]}" == "Error from server ([containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviaenv"* ]]
+  [[ "${lines[3]}" == "Error from server ([containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: DeploymentConfig/xmxviacommand"* ]]
+  [[ "${lines[4]}" == "Error from server ([containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: DeploymentConfig/xmxviaargs"* ]]
+  [[ "${lines[5]}" == "Error from server ([containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: DeploymentConfig/xmxviaenv"* ]]
   [[ "${#lines[@]}" -eq 6 ]]
 }
 
@@ -128,8 +128,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerlabelkeyinconsistent] RHCOP-OCP_BESTPRACT-00006: Deployment/nonestandardlabel"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerlabelkeyinconsistent] RHCOP-OCP_BESTPRACT-00006: DeploymentConfig/nonestandardlabel"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerlabelkeyinconsistent] RHCOP-OCP_BESTPRACT-00006: Deployment/nonestandardlabel"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerlabelkeyinconsistent] RHCOP-OCP_BESTPRACT-00006: DeploymentConfig/nonestandardlabel"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -141,8 +141,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerlivenessreadinessprobeequal] RHCOP-OCP_BESTPRACT-00007: Deployment/probssetaresame"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerlivenessreadinessprobeequal] RHCOP-OCP_BESTPRACT-00007: DeploymentConfig/probssetaresame"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerlivenessreadinessprobeequal] RHCOP-OCP_BESTPRACT-00007: Deployment/probssetaresame"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerlivenessreadinessprobeequal] RHCOP-OCP_BESTPRACT-00007: DeploymentConfig/probssetaresame"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -154,8 +154,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerlivenessprobenotset] RHCOP-OCP_BESTPRACT-00008: Deployment/noproblivenessset"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerlivenessprobenotset] RHCOP-OCP_BESTPRACT-00008: DeploymentConfig/noproblivenessset"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerlivenessprobenotset] RHCOP-OCP_BESTPRACT-00008: Deployment/noproblivenessset"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerlivenessprobenotset] RHCOP-OCP_BESTPRACT-00008: DeploymentConfig/noproblivenessset"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -167,8 +167,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerreadinessprobenotset] RHCOP-OCP_BESTPRACT-00009: Deployment/noreadinessprob"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerreadinessprobenotset] RHCOP-OCP_BESTPRACT-00009: DeploymentConfig/noreadinessprob"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerreadinessprobenotset] RHCOP-OCP_BESTPRACT-00009: Deployment/noreadinessprob"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerreadinessprobenotset] RHCOP-OCP_BESTPRACT-00009: DeploymentConfig/noreadinessprob"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -180,8 +180,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourceslimitscpuset] RHCOP-OCP_BESTPRACT-00010: Deployment/resourceslimitscpuset"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerresourceslimitscpuset] RHCOP-OCP_BESTPRACT-00010: DeploymentConfig/resourceslimitscpuset"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourceslimitscpuset] RHCOP-OCP_BESTPRACT-00010: Deployment/resourceslimitscpuset"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerresourceslimitscpuset] RHCOP-OCP_BESTPRACT-00010: DeploymentConfig/resourceslimitscpuset"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -193,8 +193,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourceslimitsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00011: Deployment/memorylimittoolarge"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerresourceslimitsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00011: DeploymentConfig/memorylimittoolarge"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourceslimitsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00011: Deployment/memorylimittoolarge"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerresourceslimitsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00011: DeploymentConfig/memorylimittoolarge"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -206,8 +206,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourceslimitsmemorynotset] RHCOP-OCP_BESTPRACT-00012: Deployment/resourcelimitsmemorynotset"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerresourceslimitsmemorynotset] RHCOP-OCP_BESTPRACT-00012: DeploymentConfig/resourcelimitsmemorynotset"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourceslimitsmemorynotset] RHCOP-OCP_BESTPRACT-00012: Deployment/resourcelimitsmemorynotset"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerresourceslimitsmemorynotset] RHCOP-OCP_BESTPRACT-00012: DeploymentConfig/resourcelimitsmemorynotset"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -219,10 +219,10 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: Deployment/invalidresourcesrequestsmemoryunits"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: Deployment/invalidresourceslimitsmemoryunits"* ]]
-  [[ "${lines[2]}" == "Error from server ([denied by containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: DeploymentConfig/invalidresourcesrequestsmemoryunits"* ]]
-  [[ "${lines[3]}" == "Error from server ([denied by containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: DeploymentConfig/invalidresourceslimitsmemoryunits"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: Deployment/invalidresourcesrequestsmemoryunits"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: Deployment/invalidresourceslimitsmemoryunits"* ]]
+  [[ "${lines[2]}" == "Error from server ([containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: DeploymentConfig/invalidresourcesrequestsmemoryunits"* ]]
+  [[ "${lines[3]}" == "Error from server ([containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: DeploymentConfig/invalidresourceslimitsmemoryunits"* ]]
   [[ "${#lines[@]}" -eq 4 ]]
 }
 
@@ -234,8 +234,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourcesrequestscpuunitincorrect] RHCOP-OCP_BESTPRACT-00014: Deployment/invalidresourcesrequestcpuunits"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerresourcesrequestscpuunitincorrect] RHCOP-OCP_BESTPRACT-00014: DeploymentConfig/invalidresourcesrequestcpuunits"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourcesrequestscpuunitincorrect] RHCOP-OCP_BESTPRACT-00014: Deployment/invalidresourcesrequestcpuunits"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerresourcesrequestscpuunitincorrect] RHCOP-OCP_BESTPRACT-00014: DeploymentConfig/invalidresourcesrequestcpuunits"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -247,8 +247,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourcesrequestsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00015: Deployment/memoryrequesttoolarge"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerresourcesrequestsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00015: DeploymentConfig/memoryrequesttoolarge"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourcesrequestsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00015: Deployment/memoryrequesttoolarge"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerresourcesrequestsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00015: DeploymentConfig/memoryrequesttoolarge"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -260,8 +260,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containersecretmountedenvs] RHCOP-OCP_BESTPRACT-00016: Deployment/secretenvvars"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containersecretmountedenvs] RHCOP-OCP_BESTPRACT-00016: DeploymentConfig/secretenvvars"* ]]
+  [[ "${lines[0]}" == "Error from server ([containersecretmountedenvs] RHCOP-OCP_BESTPRACT-00016: Deployment/secretenvvars"* ]]
+  [[ "${lines[1]}" == "Error from server ([containersecretmountedenvs] RHCOP-OCP_BESTPRACT-00016: DeploymentConfig/secretenvvars"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -273,8 +273,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containervolumemountinconsistentpath] RHCOP-OCP_BESTPRACT-00017: Deployment/notvarrunvolumemountspath"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containervolumemountinconsistentpath] RHCOP-OCP_BESTPRACT-00017: DeploymentConfig/notvarrunvolumemountspath"* ]]
+  [[ "${lines[0]}" == "Error from server ([containervolumemountinconsistentpath] RHCOP-OCP_BESTPRACT-00017: Deployment/notvarrunvolumemountspath"* ]]
+  [[ "${lines[1]}" == "Error from server ([containervolumemountinconsistentpath] RHCOP-OCP_BESTPRACT-00017: DeploymentConfig/notvarrunvolumemountspath"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -286,8 +286,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containervolumemountmissing] RHCOP-OCP_BESTPRACT-00018: Deployment/missingvolumemount"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containervolumemountmissing] RHCOP-OCP_BESTPRACT-00018: DeploymentConfig/missingvolumemount"* ]]
+  [[ "${lines[0]}" == "Error from server ([containervolumemountmissing] RHCOP-OCP_BESTPRACT-00018: Deployment/missingvolumemount"* ]]
+  [[ "${lines[1]}" == "Error from server ([containervolumemountmissing] RHCOP-OCP_BESTPRACT-00018: DeploymentConfig/missingvolumemount"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -299,7 +299,7 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by deploymentconfigtriggerscontainername] RHCOP-OCP_BESTPRACT-00027: DeploymentConfig/deploymentconfigtriggerscontainername"* ]]
+  [[ "${lines[0]}" == "Error from server ([deploymentconfigtriggerscontainername] RHCOP-OCP_BESTPRACT-00027: DeploymentConfig/deploymentconfigtriggerscontainername"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -311,8 +311,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by podhostnetwork] RHCOP-OCP_BESTPRACT-00020: Deployment/hostnetworkisset"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by podhostnetwork] RHCOP-OCP_BESTPRACT-00020: DeploymentConfig/hostnetworkisset"* ]]
+  [[ "${lines[0]}" == "Error from server ([podhostnetwork] RHCOP-OCP_BESTPRACT-00020: Deployment/hostnetworkisset"* ]]
+  [[ "${lines[1]}" == "Error from server ([podhostnetwork] RHCOP-OCP_BESTPRACT-00020: DeploymentConfig/hostnetworkisset"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -324,8 +324,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by podreplicasbelowone] RHCOP-OCP_BESTPRACT-00021: Deployment/replicaisone"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by podreplicasbelowone] RHCOP-OCP_BESTPRACT-00021: DeploymentConfig/replicaisone"* ]]
+  [[ "${lines[0]}" == "Error from server ([podreplicasbelowone] RHCOP-OCP_BESTPRACT-00021: Deployment/replicaisone"* ]]
+  [[ "${lines[1]}" == "Error from server ([podreplicasbelowone] RHCOP-OCP_BESTPRACT-00021: DeploymentConfig/replicaisone"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -337,8 +337,8 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by podreplicasnotodd] RHCOP-OCP_BESTPRACT-00022: Deployment/replicaiseven"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by podreplicasnotodd] RHCOP-OCP_BESTPRACT-00022: DeploymentConfig/replicaiseven"* ]]
+  [[ "${lines[0]}" == "Error from server ([podreplicasnotodd] RHCOP-OCP_BESTPRACT-00022: Deployment/replicaiseven"* ]]
+  [[ "${lines[1]}" == "Error from server ([podreplicasnotodd] RHCOP-OCP_BESTPRACT-00022: DeploymentConfig/replicaiseven"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -350,7 +350,7 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by routetlsterminationnotset] RHCOP-OCP_BESTPRACT-00025: Route/tlsterminationnotset"* ]]
+  [[ "${lines[0]}" == "Error from server ([routetlsterminationnotset] RHCOP-OCP_BESTPRACT-00025: Route/tlsterminationnotset"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -395,7 +395,7 @@ teardown() {
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
 
-  [[ "${lines[0]}" == "Error from server ([denied by deploymenthasmatchingpoddisruptionbudget] RHCOP-OCP_REQ_INV-00001: Deployment/hasmissingpdb"* ]]
+  [[ "${lines[0]}" == "Error from server ([deploymenthasmatchingpoddisruptionbudget] RHCOP-OCP_REQ_INV-00001: Deployment/hasmissingpdb"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -407,7 +407,7 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by deploymenthasmatchingpvc] RHCOP-OCP_REQ_INV-00002: Deployment/hasmissingpvc"* ]]
+  [[ "${lines[0]}" == "Error from server ([deploymenthasmatchingpvc] RHCOP-OCP_REQ_INV-00002: Deployment/hasmissingpvc"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -419,7 +419,7 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by deploymenthasmatchingservice] RHCOP-OCP_REQ_INV-00003: Deployment/hasmissingsvc"* ]]
+  [[ "${lines[0]}" == "Error from server ([deploymenthasmatchingservice] RHCOP-OCP_REQ_INV-00003: Deployment/hasmissingsvc"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -431,7 +431,7 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by deploymenthasmatchingserviceaccount] RHCOP-OCP_REQ_INV-00004: Deployment/hasmissingsvcaccount"* ]]
+  [[ "${lines[0]}" == "Error from server ([deploymenthasmatchingserviceaccount] RHCOP-OCP_REQ_INV-00004: Deployment/hasmissingsvcaccount"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -443,6 +443,6 @@ teardown() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by servicehasmatchingservicemonitor] RHCOP-OCP_REQ_INV-00005: Service/hasmissingsvcmon"* ]]
+  [[ "${lines[0]}" == "Error from server ([servicehasmatchingservicemonitor] RHCOP-OCP_REQ_INV-00005: Service/hasmissingsvcmon"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }

--- a/_test/gatekeeper-k8s-integrationtests.sh
+++ b/_test/gatekeeper-k8s-integrationtests.sh
@@ -72,7 +72,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by commonk8slabelsnotset] RHCOP-OCP_BESTPRACT-00001: Deployment/nolabels"* ]]
+  [[ "${lines[0]}" == "Error from server ([commonk8slabelsnotset] RHCOP-OCP_BESTPRACT-00001: Deployment/nolabels"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -85,7 +85,7 @@ remove_ocp_resources() {
   
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerenvmaxmemorynotset] RHCOP-OCP_BESTPRACT-00002: Deployment/nodownwardmemoryenv"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerenvmaxmemorynotset] RHCOP-OCP_BESTPRACT-00002: Deployment/nodownwardmemoryenv"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -98,7 +98,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerimagelatest] RHCOP-OCP_BESTPRACT-00003: Deployment/imageuseslatesttag"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerimagelatest] RHCOP-OCP_BESTPRACT-00003: Deployment/imageuseslatesttag"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -111,7 +111,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerimageunknownregistries] RHCOP-OCP_BESTPRACT-00004: Deployment/imagefromunknownregistry"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerimageunknownregistries] RHCOP-OCP_BESTPRACT-00004: Deployment/imagefromunknownregistry"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -124,9 +124,9 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviacommand"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviaargs"* ]]
-  [[ "${lines[2]}" == "Error from server ([denied by containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviaenv"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviacommand"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviaargs"* ]]
+  [[ "${lines[2]}" == "Error from server ([containerjavaxmxset] RHCOP-OCP_BESTPRACT-00005: Deployment/xmxviaenv"* ]]
   [[ "${#lines[@]}" -eq 3 ]]
 }
 
@@ -139,7 +139,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerlabelkeyinconsistent] RHCOP-OCP_BESTPRACT-00006: Deployment/nonestandardlabel"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerlabelkeyinconsistent] RHCOP-OCP_BESTPRACT-00006: Deployment/nonestandardlabel"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -152,7 +152,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerlivenessreadinessprobeequal] RHCOP-OCP_BESTPRACT-00007: Deployment/probssetaresame"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerlivenessreadinessprobeequal] RHCOP-OCP_BESTPRACT-00007: Deployment/probssetaresame"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -165,7 +165,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerlivenessprobenotset] RHCOP-OCP_BESTPRACT-00008: Deployment/noproblivenessset"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerlivenessprobenotset] RHCOP-OCP_BESTPRACT-00008: Deployment/noproblivenessset"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -178,7 +178,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerreadinessprobenotset] RHCOP-OCP_BESTPRACT-00009: Deployment/noreadinessprob"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerreadinessprobenotset] RHCOP-OCP_BESTPRACT-00009: Deployment/noreadinessprob"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -191,7 +191,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourceslimitscpuset] RHCOP-OCP_BESTPRACT-00010: Deployment/resourceslimitscpuset"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourceslimitscpuset] RHCOP-OCP_BESTPRACT-00010: Deployment/resourceslimitscpuset"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -204,7 +204,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourceslimitsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00011: Deployment/memorylimittoolarge"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourceslimitsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00011: Deployment/memorylimittoolarge"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -217,7 +217,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourceslimitsmemorynotset] RHCOP-OCP_BESTPRACT-00012: Deployment/resourcelimitsmemorynotset"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourceslimitsmemorynotset] RHCOP-OCP_BESTPRACT-00012: Deployment/resourcelimitsmemorynotset"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -230,8 +230,8 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: Deployment/invalidresourcesrequestsmemoryunits"* ]]
-  [[ "${lines[1]}" == "Error from server ([denied by containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: Deployment/invalidresourceslimitsmemoryunits"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: Deployment/invalidresourcesrequestsmemoryunits"* ]]
+  [[ "${lines[1]}" == "Error from server ([containerresourcesmemoryunitincorrect] RHCOP-OCP_BESTPRACT-00013: Deployment/invalidresourceslimitsmemoryunits"* ]]
   [[ "${#lines[@]}" -eq 2 ]]
 }
 
@@ -244,7 +244,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourcesrequestscpuunitincorrect] RHCOP-OCP_BESTPRACT-00014: Deployment/invalidresourcesrequestcpuunits"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourcesrequestscpuunitincorrect] RHCOP-OCP_BESTPRACT-00014: Deployment/invalidresourcesrequestcpuunits"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -257,7 +257,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containerresourcesrequestsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00015: Deployment/memoryrequesttoolarge"* ]]
+  [[ "${lines[0]}" == "Error from server ([containerresourcesrequestsmemorygreaterthan] RHCOP-OCP_BESTPRACT-00015: Deployment/memoryrequesttoolarge"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -270,7 +270,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containersecretmountedenvs] RHCOP-OCP_BESTPRACT-00016: Deployment/secretenvvars"* ]]
+  [[ "${lines[0]}" == "Error from server ([containersecretmountedenvs] RHCOP-OCP_BESTPRACT-00016: Deployment/secretenvvars"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -283,7 +283,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containervolumemountinconsistentpath] RHCOP-OCP_BESTPRACT-00017: Deployment/notvarrunvolumemountspath"* ]]
+  [[ "${lines[0]}" == "Error from server ([containervolumemountinconsistentpath] RHCOP-OCP_BESTPRACT-00017: Deployment/notvarrunvolumemountspath"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -296,7 +296,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by containervolumemountmissing] RHCOP-OCP_BESTPRACT-00018: Deployment/missingvolumemount"* ]]
+  [[ "${lines[0]}" == "Error from server ([containervolumemountmissing] RHCOP-OCP_BESTPRACT-00018: Deployment/missingvolumemount"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -309,7 +309,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by podhostnetwork] RHCOP-OCP_BESTPRACT-00020: Deployment/hostnetworkisset"* ]]
+  [[ "${lines[0]}" == "Error from server ([podhostnetwork] RHCOP-OCP_BESTPRACT-00020: Deployment/hostnetworkisset"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -322,7 +322,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by podreplicasbelowone] RHCOP-OCP_BESTPRACT-00021: Deployment/replicaisone"* ]]
+  [[ "${lines[0]}" == "Error from server ([podreplicasbelowone] RHCOP-OCP_BESTPRACT-00021: Deployment/replicaisone"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 
@@ -335,7 +335,7 @@ remove_ocp_resources() {
 
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error from server ([denied by podreplicasnotodd] RHCOP-OCP_BESTPRACT-00022: Deployment/replicaiseven"* ]]
+  [[ "${lines[0]}" == "Error from server ([podreplicasnotodd] RHCOP-OCP_BESTPRACT-00022: Deployment/replicaiseven"* ]]
   [[ "${#lines[@]}" -eq 1 ]]
 }
 


### PR DESCRIPTION
#### What is this PR About?
Fixes CI as `kind` was failing due to validating webhook deprecation 

#### Check list
- [x] Have you created a test case in `_test/conftest-unittests.sh`
- [x] Have you created a test case in `_test/opa-profile.sh`
- [x] Have you created a test case in `_test/gatekeeper-integrationtests.sh`
- [x] Have you created a test case in `_test/gatekeeper-k8s-integrationtests.sh`
- [x] Have you followed the TESTING.md doc? If not, please provide commands/steps to test this PR.
- [x] Have you re-generated `POLICIES.md`

cc: @redhat-cop/rego-policies
