### PR TITLE
updated volume path for kube mount due to image changes

### DIFF
--- a/.github/workflows/gatekeeper-k8s-integrationtests.yaml
+++ b/.github/workflows/gatekeeper-k8s-integrationtests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Test against KinD
         run: |
           confbatstest=$(docker images --filter=label=com.github.actions.name=confbatstest --format "{{.Repository}}:{{.Tag}}")
-          docker run --rm --network host --workdir /conftest --volume "/home/runner/.kube/":"/root/.kube/" --volume "/home/runner/work/rego-policies/rego-policies":"/conftest" --entrypoint .github/workflows/tests-entrypoint.sh ${confbatstest}
+          docker run --rm --network host --workdir /conftest --volume "/home/runner/.kube/":"/opt/app-root/src/.kube/" --volume "/home/runner/work/rego-policies/rego-policies":"/conftest" --entrypoint .github/workflows/tests-entrypoint.sh ${confbatstest}
 
       - name: Get pods and events if tests failed
         if: ${{ failure() }}

--- a/.github/workflows/tests-entrypoint.sh
+++ b/.github/workflows/tests-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 kubectl cluster-info
 _test/prow.sh deploy
 


### PR DESCRIPTION
#### What is this PR About?
fixes the CI due to the action image changes, it was failing for `kind`.

cc: @redhat-cop/rego-policies
